### PR TITLE
Add stubs and enforce integration failure

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,11 +12,12 @@ jobs:
       - uses: actions/checkout@v4.2.1
       - uses: actions/setup-python@v5
         with:
-          # Home Assistant wheels are built for Python 3.12
-          python-version: '3.12'
+          python-version: '3.13'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip
-          pip install -r requirements.txt -r requirements-dev.txt
+          python -m pip install pre_commit
+          pip install pre_commit
+          scripts/setup
       - name: Run tests
         run: scripts/test

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -12,7 +12,8 @@ jobs:
       - uses: actions/checkout@v4.2.1
       - uses: actions/setup-python@v5
         with:
-          python-version: '3.13'
+          # Home Assistant wheels are built for Python 3.12
+          python-version: '3.12'
       - name: Install dependencies
         run: |
           python -m pip install --upgrade pip

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,68 @@
+import sys
+import types
+import math
+import datetime as dt
+from pathlib import Path
+from importlib import util
+import pytest
+
+# ---------------------------------------------------------------------------
+# Minimal stubs for third party dependencies (numpy, pandas, pytz, dateutil)
+# ---------------------------------------------------------------------------
+
+numpy_stub = types.ModuleType("numpy")
+numpy_stub.interp = (
+    lambda x, xp, fp: fp[0] + (fp[1] - fp[0]) * (x - xp[0]) / (xp[1] - xp[0]) if xp[1] - xp[0] else fp[0]
+)
+numpy_stub.cos = math.cos
+numpy_stub.sin = math.sin
+numpy_stub.tan = math.tan
+numpy_stub.clip = lambda x, low, high: max(min(x, high), low)
+numpy_stub.radians = math.radians
+numpy_stub.rad2deg = math.degrees
+numpy_stub.arctan = math.atan
+numpy_stub.sqrt = math.sqrt
+numpy_stub.where = lambda cond, a, b: a if cond else b
+numpy_stub.isscalar = lambda obj: isinstance(obj, (int, float, complex))
+sys.modules.setdefault("numpy", numpy_stub)
+
+pandas_stub = types.ModuleType("pandas")
+sys.modules.setdefault("pandas", pandas_stub)
+
+pytz_stub = types.ModuleType("pytz")
+pytz_stub.UTC = dt.UTC
+sys.modules.setdefault("pytz", pytz_stub)
+
+dateutil = types.ModuleType("dateutil")
+parser_stub = types.ModuleType("dateutil.parser")
+parser_stub.parse = lambda *a, **k: dt.datetime.now(dt.UTC)
+dateutil.parser = parser_stub
+sys.modules.setdefault("dateutil", dateutil)
+sys.modules.setdefault("dateutil.parser", parser_stub)
+
+# ---------------------------------------------------------------------------
+# Helper to load integration modules from file paths
+# ---------------------------------------------------------------------------
+
+def import_module(path: str, name: str):
+    spec = util.spec_from_file_location(name, Path(__file__).resolve().parents[1] / path)
+    module = util.module_from_spec(spec)
+    assert spec.loader is not None
+    spec.loader.exec_module(module)
+    return module
+
+
+@pytest.fixture
+def calculation():
+    return import_module(
+        "custom_components/simple_auto_cover/calculation.py",
+        "custom_components.simple_auto_cover.calculation",
+    )
+
+
+@pytest.fixture
+def coordinator():
+    return import_module(
+        "custom_components/simple_auto_cover/coordinator.py",
+        "custom_components.simple_auto_cover.coordinator",
+    )

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -27,6 +27,7 @@ numpy_stub.isscalar = lambda obj: isinstance(obj, (int, float, complex))
 sys.modules.setdefault("numpy", numpy_stub)
 
 pandas_stub = types.ModuleType("pandas")
+pandas_stub.DatetimeIndex = list
 sys.modules.setdefault("pandas", pandas_stub)
 
 pytz_stub = types.ModuleType("pytz")
@@ -45,9 +46,16 @@ sys.modules.setdefault("dateutil.parser", parser_stub)
 # ---------------------------------------------------------------------------
 
 def import_module(path: str, name: str):
-    spec = util.spec_from_file_location(name, Path(__file__).resolve().parents[1] / path)
+    root = Path(__file__).resolve().parents[1]
+    if str(root) not in sys.path:
+        sys.path.insert(0, str(root))
+    package = name.rpartition(".")[0]
+    if package and package not in sys.modules:
+        __import__(package)
+    spec = util.spec_from_file_location(name, root / path)
     module = util.module_from_spec(spec)
     assert spec.loader is not None
+    sys.modules[spec.name] = module
     spec.loader.exec_module(module)
     return module
 

--- a/tests/test_calculation.py
+++ b/tests/test_calculation.py
@@ -2,144 +2,62 @@
 
 from __future__ import annotations
 
-import sys
-import types
-import math
-from pathlib import Path
-from importlib import util
+import datetime as dt
 import pytest
 
-np_stub = types.ModuleType("numpy")
-np_stub.cos = math.cos
-np_stub.sin = math.sin
-np_stub.tan = math.tan
-np_stub.clip = lambda x, low, high: max(min(x, high), low)
-np_stub.radians = math.radians
-np_stub.rad2deg = math.degrees
-np_stub.arctan = math.atan
-np_stub.sqrt = math.sqrt
-np_stub.where = lambda cond, a, b: a if cond else b
-np_stub.isscalar = lambda obj: isinstance(obj, int | float | complex)
-sys.modules.setdefault("numpy", np_stub)
 
-pandas_stub = types.ModuleType("pandas")
-sys.modules.setdefault("pandas", pandas_stub)
-
-homeassistant = types.ModuleType("homeassistant")
-core = types.ModuleType("homeassistant.core")
-
-util_module = types.ModuleType("homeassistant.util")
-logging_module = types.ModuleType("homeassistant.util.logging")
-logging_module.log_exception = lambda *a, **k: None
-util_module.logging = logging_module
+@pytest.fixture
+def module(calculation):
+    return calculation
 
 
-class HomeAssistant:  # pragma: no cover - minimal stub
-    """Stub for Home Assistant object used in tests."""
+class TestVerticalCover:
+    @staticmethod
+    def make_cover(calculation_module, **kwargs):
+        class DummyCover(calculation_module.AdaptiveVerticalCover):
+            __test__ = False
 
-    pass
+            def __post_init__(self):
+                pass
 
-
-core.HomeAssistant = HomeAssistant
-homeassistant.core = core
-homeassistant.util = util_module
-sys.modules.setdefault("homeassistant", homeassistant)
-sys.modules.setdefault("homeassistant.core", core)
-sys.modules.setdefault("homeassistant.util", util_module)
-sys.modules.setdefault("homeassistant.util.logging", logging_module)
-
-custom_components = types.ModuleType("custom_components")
-simple_auto_cover = types.ModuleType("custom_components.simple_auto_cover")
-custom_components.simple_auto_cover = simple_auto_cover
-custom_components.__path__ = [
-    str(Path(__file__).resolve().parents[1] / "custom_components")
-]
-simple_auto_cover.__path__ = [
-    str(Path(__file__).resolve().parents[1] / "custom_components/simple_auto_cover")
-]
-sys.modules.setdefault("custom_components", custom_components)
-sys.modules.setdefault("custom_components.simple_auto_cover", simple_auto_cover)
-
-sun_stub = types.ModuleType("custom_components.simple_auto_cover.sun")
-
-
-class SunData:  # pragma: no cover - minimal stub
-    """Stub for SunData class."""
-
-    def __init__(self, *args, **kwargs) -> None:
-        """Initialize SunData stub."""
-        pass
-
-
-sun_stub.SunData = SunData
-sys.modules.setdefault("custom_components.simple_auto_cover.sun", sun_stub)
-
-spec = util.spec_from_file_location(
-    "custom_components.simple_auto_cover.calculation",
-    Path(__file__).resolve().parents[1]
-    / "custom_components/simple_auto_cover/calculation.py",
-)
-calc = util.module_from_spec(spec)
-assert spec.loader is not None
-spec.loader.exec_module(calc)
-
-AdaptiveVerticalCover = calc.AdaptiveVerticalCover
-NormalCoverState = calc.NormalCoverState
+        defaults = {
+            "hass": None,
+            "sol_azi": 0,
+            "sol_elev": 45,
+            "sunset_pos": 0,
+            "sunset_off": 0,
+            "sunrise_off": 0,
+            "timezone": "UTC",
+            "fov_left": 90,
+            "fov_right": 90,
+            "win_azi": 0,
+            "h_def": 0,
+            "max_pos": 100,
+            "min_pos": 0,
+            "max_pos_bool": False,
+            "min_pos_bool": False,
+            "blind_spot_left": None,
+            "blind_spot_right": None,
+            "blind_spot_elevation": None,
+            "blind_spot_on": False,
+            "min_elevation": None,
+            "max_elevation": None,
+            "distance": 1,
+            "h_win": 2,
+        }
+        defaults.update(kwargs)
+        cover = DummyCover(**defaults)
+        cover.sun_data = None
+        return cover
 
 
-class TestVerticalCover(AdaptiveVerticalCover):
-    """Vertical cover that skips sun data setup."""
-
-    def __post_init__(self):
-        """Avoid SunData initialization during tests."""
-        pass
-
-    __test__ = False
-
-
-def make_cover(**kwargs):
-    """Create a ``TestVerticalCover`` instance with defaults."""
-
-    defaults = {
-        "hass": None,
-        "sol_azi": 0,
-        "sol_elev": 45,
-        "sunset_pos": 0,
-        "sunset_off": 0,
-        "sunrise_off": 0,
-        "timezone": "UTC",
-        "fov_left": 90,
-        "fov_right": 90,
-        "win_azi": 0,
-        "h_def": 0,
-        "max_pos": 100,
-        "min_pos": 0,
-        "max_pos_bool": False,
-        "min_pos_bool": False,
-        "blind_spot_left": None,
-        "blind_spot_right": None,
-        "blind_spot_elevation": None,
-        "blind_spot_on": False,
-        "min_elevation": None,
-        "max_elevation": None,
-        "distance": 1,
-        "h_win": 2,
-    }
-    defaults.update(kwargs)
-    cover = TestVerticalCover(**defaults)
-    cover.sun_data = None
-    return cover
-
-
-def test_vertical_cover_calculation():
-    """Verify basic position and percentage calculations."""
-    cover = make_cover()
+def test_vertical_cover_calculation(module):
+    cover = TestVerticalCover.make_cover(module)
     assert cover.calculate_position() == pytest.approx(1)
     assert cover.calculate_percentage() == 50
 
 
-def test_normal_cover_state_default():
-    """Ensure default value is used when sun is not valid."""
+def test_normal_cover_state_default(module):
     class DummyCover:
         def __init__(self):
             self.direct_sun_valid = False
@@ -152,12 +70,11 @@ def test_normal_cover_state_default():
         def calculate_percentage(self):
             return 80
 
-    state = NormalCoverState(DummyCover())
+    state = module.NormalCoverState(DummyCover())
     assert state.get_state() == 30
 
 
-def test_normal_cover_state_apply_max():
-    """Ensure max position is respected when exceeded."""
+def test_normal_cover_state_apply_max(module):
     class DummyCover:
         def __init__(self):
             self.direct_sun_valid = True
@@ -170,6 +87,5 @@ def test_normal_cover_state_apply_max():
         def calculate_percentage(self):
             return 80
 
-    state = NormalCoverState(DummyCover())
+    state = module.NormalCoverState(DummyCover())
     assert state.get_state() == 50
-

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -1,250 +1,53 @@
 """Tests for the adaptive cover coordinator."""
 
-import sys
-import types
-import math
+from __future__ import annotations
+
 import datetime as dt
-from pathlib import Path
-from importlib import util
-import dataclasses
+import types
+import pytest
 
 
-# Stub numpy functions used by the module
-np_stub = types.ModuleType("numpy")
-np_stub.interp = lambda x, xp, fp: fp[0] + (fp[1] - fp[0]) * (x - xp[0]) / (xp[1] - xp[0]) if xp[1] - xp[0] else fp[0]
-np_stub.cos = math.cos
-np_stub.sin = math.sin
-np_stub.tan = math.tan
-np_stub.clip = lambda x, low, high: max(min(x, high), low)
-np_stub.radians = math.radians
-np_stub.rad2deg = math.degrees
-np_stub.arctan = math.atan
-np_stub.sqrt = math.sqrt
-np_stub.where = lambda cond, a, b: a if cond else b
-np_stub.isscalar = lambda obj: isinstance(obj, int | float | complex)
-sys.modules.setdefault("numpy", np_stub)
-
-# Minimal pandas stub
-pandas_stub = types.ModuleType("pandas")
-sys.modules.setdefault("pandas", pandas_stub)
-
-# Minimal pytz stub
-pytz_stub = types.ModuleType("pytz")
-pytz_stub.UTC = dt.UTC
-sys.modules.setdefault("pytz", pytz_stub)
-
-# Minimal dateutil parser stub
-dateutil = types.ModuleType("dateutil")
-parser_stub = types.ModuleType("dateutil.parser")
-parser_stub.parse = lambda *a, **k: dt.datetime.now(dt.UTC)
-dateutil.parser = parser_stub
-sys.modules.setdefault("dateutil", dateutil)
-sys.modules.setdefault("dateutil.parser", parser_stub)
-
-# Simplify dataclass decorator
-
-
-def simple_dataclass(cls=None, **kwargs):
-    """Return class unchanged for dataclass stub."""
-
-    return cls if cls is not None else (lambda c: c)
-
-dataclasses.dataclass = simple_dataclass
-
-# Home Assistant stubs -------------------------------------------------------
-core = types.ModuleType("homeassistant.core")
+@pytest.fixture
+def module(coordinator):
+    return coordinator
 
 
 class DummyStates(dict):
-    """Dictionary-like container for states."""
-
     def get(self, entity_id):
-        """Return state for ``entity_id``."""
         return super().get(entity_id)
 
-class HomeAssistant:  # pragma: no cover - minimal stub
-    """Minimal Home Assistant object."""
 
-    def __init__(self):  # noqa: D107 - simple stub
+class HomeAssistant:
+    def __init__(self, config_dir: str = "/tmp") -> None:
         self.states = DummyStates()
         self.services = types.SimpleNamespace(async_call=lambda *a, **kw: None)
         self.config = types.SimpleNamespace(time_zone="UTC")
 
-def split_entity_id(entity_id: str):
-    """Split entity ID into domain and object ID."""
-    return tuple(entity_id.split("."))
 
-class Event:  # pragma: no cover - minimal stub
-    """Dummy event class."""
-
-    pass
-
-class EventStateChangedData:  # pragma: no cover - minimal stub
-    """Dummy event data class."""
-
-    pass
-
-class State:  # pragma: no cover - minimal stub
-    """Simple representation of an entity state."""
-
-    def __init__(self, state, attributes=None, last_updated=None):  # noqa: D107
-        self.state = state
-        self.attributes = attributes or {}
-        self.last_updated = last_updated or dt.datetime.now(dt.UTC)
-
-def callback(func):  # pragma: no cover - minimal stub
-    """Return function unchanged (decorator stub)."""
-    return func
-
-core.HomeAssistant = HomeAssistant
-core.Event = Event
-core.EventStateChangedData = EventStateChangedData
-core.State = State
-core.callback = callback
-core.split_entity_id = split_entity_id
-
-config_entries = types.ModuleType("homeassistant.config_entries")
-
-class ConfigEntry:  # pragma: no cover - minimal stub
-    """Configuration entry container."""
-
-    def __init__(self):  # noqa: D107 - simple stub
-        self.data = {}
-        self.options = {}
-        self.entry_id = "test"
-
-config_entries.ConfigEntry = ConfigEntry
-
-const = types.ModuleType("homeassistant.const")
-const.ATTR_ENTITY_ID = "entity_id"
-const.SERVICE_SET_COVER_POSITION = "set_cover_position"
-const.SERVICE_SET_COVER_TILT_POSITION = "set_cover_tilt_position"
-
-util_module = types.ModuleType("homeassistant.util")
-logging_module = types.ModuleType("homeassistant.util.logging")
-logging_module.log_exception = lambda *a, **k: None
-util_module.logging = logging_module
-
-helpers_update_coordinator = types.ModuleType("homeassistant.helpers.update_coordinator")
-
-class DataUpdateCoordinator:  # pragma: no cover - minimal stub
-    """Simplified data update coordinator."""
-
-    def __init__(self, hass, logger, name="") -> None:  # noqa: D107
-        self.hass = hass
-        self.logger = logger
-        self.name = name
-        self.config_entry = ConfigEntry()
-
-    async def async_config_entry_first_refresh(self):
-        """Return placeholder result."""
-        return None
-
-    async def async_refresh(self):  # noqa: D401 - minimal stub
-        """Return placeholder result."""
-        return None
-
-    @classmethod
-    def __class_getitem__(cls, item):  # pragma: no cover - support generics
-        """Ignore subscription and return the class itself."""
-        return cls
-
-helpers_update_coordinator.DataUpdateCoordinator = DataUpdateCoordinator
-
-helpers_event = types.ModuleType("homeassistant.helpers.event")
-async def async_track_point_in_time(hass, func, time):  # pragma: no cover - stub
-    """Stub for ``async_track_point_in_time``."""
-    return None
-helpers_event.async_track_point_in_time = async_track_point_in_time
-
-helpers_template = types.ModuleType("homeassistant.helpers.template")
-def state_attr(hass, entity, attribute):  # pragma: no cover - stub
-    """Retrieve attribute for entity."""
-    state = hass.states.get(entity)
-    if state:
-        return state.attributes.get(attribute)
-    return None
-helpers_template.state_attr = state_attr
-
-components_cover = types.ModuleType("homeassistant.components.cover")
-components_cover.DOMAIN = "cover"
-
-homeassistant = types.ModuleType("homeassistant")
-homeassistant.__path__ = []
-homeassistant.core = core
-homeassistant.util = util_module
-homeassistant.config_entries = config_entries
-homeassistant.const = const
-homeassistant.helpers = types.ModuleType("homeassistant.helpers")
-homeassistant.helpers.update_coordinator = helpers_update_coordinator
-homeassistant.helpers.event = helpers_event
-homeassistant.helpers.template = helpers_template
-homeassistant.components = types.ModuleType("homeassistant.components")
-homeassistant.components.cover = components_cover
-
-sys.modules["homeassistant"] = homeassistant
-sys.modules["homeassistant.core"] = core
-sys.modules["homeassistant.util"] = util_module
-sys.modules["homeassistant.util.logging"] = logging_module
-sys.modules["homeassistant.config_entries"] = config_entries
-sys.modules["homeassistant.const"] = const
-sys.modules["homeassistant.helpers.update_coordinator"] = helpers_update_coordinator
-sys.modules["homeassistant.helpers.event"] = helpers_event
-sys.modules["homeassistant.helpers.template"] = helpers_template
-sys.modules["homeassistant.components.cover"] = components_cover
-
-# custom_components package stub --------------------------------------------
-custom_components = types.ModuleType("custom_components")
-simple_auto_cover = types.ModuleType("custom_components.simple_auto_cover")
-custom_components.__path__ = [str(Path(__file__).resolve().parents[1] / "custom_components")]
-simple_auto_cover.__path__ = [str(Path(__file__).resolve().parents[1] / "custom_components/simple_auto_cover")]
-custom_components.simple_auto_cover = simple_auto_cover
-sys.modules.setdefault("custom_components", custom_components)
-sys.modules.setdefault("custom_components.simple_auto_cover", simple_auto_cover)
-
-# Import the coordinator module
-spec = util.spec_from_file_location(
-    "custom_components.simple_auto_cover.coordinator",
-    Path(__file__).resolve().parents[1] / "custom_components/simple_auto_cover/coordinator.py",
-)
-coordinator = util.module_from_spec(spec)
-assert spec.loader is not None
-spec.loader.exec_module(coordinator)
-
-AdaptiveDataUpdateCoordinator = coordinator.AdaptiveDataUpdateCoordinator
-inverse_state = coordinator.inverse_state
-CONF_SUNSET_POS = coordinator.CONF_SUNSET_POS
-CONF_DEFAULT_HEIGHT = coordinator.CONF_DEFAULT_HEIGHT
-
-# Helper factory -------------------------------------------------------------
-
-def make_coordinator(cover_type="cover_blind"):
-    """Create a coordinator with default options."""
-
+def make_coordinator(module, cover_type="cover_blind"):
     hass = HomeAssistant()
-    coord = AdaptiveDataUpdateCoordinator(hass)
+    coord = module.AdaptiveDataUpdateCoordinator.__new__(module.AdaptiveDataUpdateCoordinator)
+    coord.hass = hass
+    coord.config_entry = types.SimpleNamespace(data={}, options={})
     coord._cover_type = cover_type
     coord.min_change = 10
     coord.time_threshold = 2
     return coord, hass
 
-# Tests ----------------------------------------------------------------------
 
-def test_get_current_position():
-    """Return current position attribute based on cover type."""
-    coord, hass = make_coordinator("cover_blind")
-    hass.states["cover.test"] = State("open", {"current_position": 40})
+def test_get_current_position(module):
+    coord, hass = make_coordinator(module, "cover_blind")
+    hass.states["cover.test"] = module.State("cover.test", "open", {"current_position": 40})
     assert coord._get_current_position("cover.test") == 40
 
     coord._cover_type = "cover_tilt"
-    hass.states["cover.test"] = State("open", {"current_tilt_position": 30})
+    hass.states["cover.test"] = module.State("cover.test", "open", {"current_tilt_position": 30})
     assert coord._get_current_position("cover.test") == 30
 
 
-def test_check_position():
-    """Verify position difference logic."""
-    coord, hass = make_coordinator()
-    hass.states["cover.test"] = State("open", {"current_position": 40})
+def test_check_position(module):
+    coord, hass = make_coordinator(module)
+    hass.states["cover.test"] = module.State("cover.test", "open", {"current_position": 40})
     assert coord.check_position("cover.test", 50) is True
     assert coord.check_position("cover.test", 40) is False
 
@@ -252,11 +55,10 @@ def test_check_position():
     assert coord.check_position("cover.test", 30) is False
 
 
-def test_check_position_delta():
-    """Ensure delta checks honor thresholds and defaults."""
-    coord, hass = make_coordinator()
-    hass.states["cover.test"] = State("open", {"current_position": 40})
-    options = {CONF_SUNSET_POS: 0, CONF_DEFAULT_HEIGHT: 50}
+def test_check_position_delta(module):
+    coord, hass = make_coordinator(module)
+    hass.states["cover.test"] = module.State("cover.test", "open", {"current_position": 40})
+    options = {module.CONF_SUNSET_POS: 0, module.CONF_DEFAULT_HEIGHT: 50}
 
     assert coord.check_position_delta("cover.test", 45, options) is False
     assert coord.check_position_delta("cover.test", 55, options) is True
@@ -266,11 +68,10 @@ def test_check_position_delta():
     assert coord.check_position_delta("cover.test", 30, options) is True
 
 
-def test_check_time_delta():
-    """Validate time delta behaviour."""
-    coord, hass = make_coordinator()
+def test_check_time_delta(module):
+    coord, hass = make_coordinator(module)
     past = dt.datetime.now(dt.UTC) - dt.timedelta(minutes=3)
-    hass.states["cover.test"] = State("open", last_updated=past)
+    hass.states["cover.test"] = module.State("cover.test", "open", last_updated=past)
     assert coord.check_time_delta("cover.test") is True
 
     hass.states["cover.test"].last_updated = dt.datetime.now(dt.UTC) - dt.timedelta(minutes=1)
@@ -280,7 +81,5 @@ def test_check_time_delta():
     assert coord.check_time_delta("cover.test") is True
 
 
-def test_inverse_state():
-    """Inverse a state value."""
-    assert inverse_state(20) == 80
-
+def test_inverse_state(module):
+    assert module.inverse_state(20) == 80

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,57 +1,23 @@
-"""System tests for the Simple Auto Cover integration."""
+"""Basic integration test for Simple Auto Cover."""
 
 from __future__ import annotations
 
 import importlib
 import sys
+from pathlib import Path
 import pytest
 
-# Ensure the real Home Assistant package is used for this integration test.
-pytest.importorskip("homeassistant")
-for name in [m for m in list(sys.modules) if m.startswith("homeassistant")]:
-    sys.modules.pop(name)
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+for mod in ["numpy", "pandas", "pytz", "dateutil", "dateutil.parser"]:
+    sys.modules.pop(mod, None)
 importlib.invalidate_caches()
 
-try:  # pragma: no cover - fail if Home Assistant is missing
-    from homeassistant.config_entries import ConfigEntryState
-    from pytest_homeassistant_custom_component.common import MockConfigEntry
-except Exception as exc:  # pragma: no cover - not installed
-    pytest.fail(f"Home Assistant not available: {exc}")
-
-from custom_components.simple_auto_cover import DOMAIN
-from custom_components.simple_auto_cover.const import (
-    CONF_AZIMUTH,
-    CONF_DEFAULT_HEIGHT,
-    CONF_FOV_LEFT,
-    CONF_FOV_RIGHT,
-    CONF_MODE,
-    CONF_SENSOR_TYPE,
-    SensorType,
-)
+try:
+    import custom_components.simple_auto_cover as sac
+except Exception as exc:
+    pytest.fail(f"Integration failed to load: {exc}")
 
 
-@pytest.mark.asyncio
-async def test_full_setup_and_unload(hass):
-    """Test setting up and unloading the integration."""
-    entry = MockConfigEntry(
-        domain=DOMAIN,
-        data={"name": "Test", CONF_SENSOR_TYPE: SensorType.BLIND},
-        options={
-            CONF_MODE: "basic",
-            CONF_AZIMUTH: 180,
-            CONF_FOV_LEFT: 90,
-            CONF_FOV_RIGHT: 90,
-            CONF_DEFAULT_HEIGHT: 60,
-        },
-    )
-    entry.add_to_hass(hass)
-
-    assert await hass.config_entries.async_setup(entry.entry_id)
-    await hass.async_block_till_done()
-
-    assert entry.state is ConfigEntryState.LOADED
-    assert DOMAIN in hass.data
-
-    assert await hass.config_entries.async_unload(entry.entry_id)
-    await hass.async_block_till_done()
-    assert entry.state is ConfigEntryState.NOT_LOADED
+def test_import_success():
+    """Ensure the integration imports without errors."""
+    assert sac.DOMAIN == "simple_auto_cover"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2,15 +2,21 @@
 
 from __future__ import annotations
 
+import importlib
+import sys
 import pytest
 
+# Ensure the real Home Assistant package is used for this integration test.
 pytest.importorskip("homeassistant")
+for name in [m for m in list(sys.modules) if m.startswith("homeassistant")]:
+    sys.modules.pop(name)
+importlib.invalidate_caches()
 
-try:  # pragma: no cover - skip if Home Assistant is missing
+try:  # pragma: no cover - fail if Home Assistant is missing
     from homeassistant.config_entries import ConfigEntryState
     from pytest_homeassistant_custom_component.common import MockConfigEntry
-except Exception:  # pragma: no cover - not installed
-    pytest.skip("homeassistant not available", allow_module_level=True)
+except Exception as exc:  # pragma: no cover - not installed
+    pytest.fail(f"Home Assistant not available: {exc}")
 
 from custom_components.simple_auto_cover import DOMAIN
 from custom_components.simple_auto_cover.const import (


### PR DESCRIPTION
## Summary
- add lightweight module stubs in `conftest.py`
- ensure the integration test fails when Home Assistant isn't available

## Testing
- `pre-commit run --files tests/test_integration.py tests/conftest.py`
- `pytest -q` *(fails: Home Assistant not available: BlockedIntegration() takes no arguments)*

------
https://chatgpt.com/codex/tasks/task_e_6855a3aebffc832e8b2f5a12028aa4ea