### PR TITLE
Expand integration tests

### DIFF
--- a/tests/test_calculation.py
+++ b/tests/test_calculation.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import datetime as dt
+import types
 import pytest
 
 
@@ -45,6 +46,11 @@ class TestVerticalCover:
             "distance": 1,
             "h_win": 2,
         }
+        if hasattr(
+            calculation_module.AdaptiveVerticalCover,
+            "__dataclass_fields__",
+        ) and "logger" in calculation_module.AdaptiveVerticalCover.__dataclass_fields__:
+            defaults.setdefault("logger", types.SimpleNamespace(debug=lambda *a, **k: None))
         defaults.update(kwargs)
         cover = DummyCover(**defaults)
         cover.sun_data = None
@@ -66,6 +72,7 @@ def test_normal_cover_state_default(module):
             self.apply_min_position = False
             self.max_pos = 100
             self.min_pos = 0
+            self.logger = types.SimpleNamespace(debug=lambda *a, **k: None)
 
         def calculate_percentage(self):
             return 80
@@ -83,6 +90,7 @@ def test_normal_cover_state_apply_max(module):
             self.max_pos = 50
             self.apply_min_position = False
             self.min_pos = 0
+            self.logger = types.SimpleNamespace(debug=lambda *a, **k: None)
 
         def calculate_percentage(self):
             return 80

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -32,6 +32,7 @@ def make_coordinator(module, cover_type="cover_blind"):
     coord._cover_type = cover_type
     coord.min_change = 10
     coord.time_threshold = 2
+    coord.logger = types.SimpleNamespace(debug=lambda *a, **k: None)
     return coord, hass
 
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -5,6 +5,7 @@ from __future__ import annotations
 import importlib
 import sys
 from pathlib import Path
+import types
 import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
@@ -21,3 +22,92 @@ except Exception as exc:
 def test_import_success():
     """Ensure the integration imports without errors."""
     assert sac.DOMAIN == "simple_auto_cover"
+
+
+class DummyConfigEntries:
+    def __init__(self):
+        self.forwarded = []
+        self.unloaded = []
+        self.reloaded = None
+
+    async def async_forward_entry_setups(self, entry, platforms):
+        self.forwarded.append((entry, platforms))
+
+    async def async_unload_platforms(self, entry, platforms):
+        self.unloaded.append((entry, platforms))
+        return True
+
+    async def async_reload(self, entry_id):
+        self.reloaded = entry_id
+
+
+class DummyHass:
+    def __init__(self):
+        self.config_entries = DummyConfigEntries()
+        self.data = {}
+
+
+class DummyEntry:
+    def __init__(self, entry_id="1", data=None, options=None):
+        self.entry_id = entry_id
+        self.data = data or {}
+        self.options = options or {}
+        self.update_listeners = []
+        self.unload_callbacks = []
+
+    def async_on_unload(self, callback):
+        self.unload_callbacks.append(callback)
+
+    def add_update_listener(self, listener):
+        self.update_listeners.append(listener)
+        return listener
+
+
+class DummyCoordinator:
+    def __init__(self, hass):
+        self.hass = hass
+        self.first_refresh = False
+
+    async def async_config_entry_first_refresh(self):
+        self.first_refresh = True
+
+    async def async_check_entity_state_change(self, *args, **kwargs):
+        pass
+
+    async def async_check_cover_state_change(self, *args, **kwargs):
+        pass
+
+
+@pytest.mark.asyncio
+async def test_initialize_and_lifecycle(monkeypatch):
+    """Test setup and unload of the integration entry."""
+
+    hass = DummyHass()
+    entry = DummyEntry(options={sac.CONF_ENTITIES: ["cover.test"]})
+
+    track_calls = []
+
+    def dummy_track_state_change_event(hass_obj, entities, callback):
+        track_calls.append(list(entities))
+        return lambda: None
+
+    monkeypatch.setattr(sac, "async_track_state_change_event", dummy_track_state_change_event)
+    monkeypatch.setattr(sac, "AdaptiveDataUpdateCoordinator", DummyCoordinator)
+
+    assert await sac.async_initialize_integration(hass) is True
+
+    assert await sac.async_setup_entry(hass, entry) is True
+    assert sac.DOMAIN in hass.data
+    assert entry.entry_id in hass.data[sac.DOMAIN]
+    coord = hass.data[sac.DOMAIN][entry.entry_id]
+    assert isinstance(coord, DummyCoordinator) and coord.first_refresh
+    assert track_calls == [["sun.sun"], ["cover.test"]]
+    assert hass.config_entries.forwarded == [(entry, sac.PLATFORMS)]
+
+    listener = entry.update_listeners[0]
+    await listener(hass, entry)
+    assert hass.config_entries.reloaded == entry.entry_id
+
+    assert await sac.async_unload_entry(hass, entry) is True
+    assert hass.config_entries.unloaded == [(entry, sac.PLATFORMS)]
+    assert entry.entry_id not in hass.data[sac.DOMAIN]


### PR DESCRIPTION
## Summary
- expand integration tests to cover setup and unload logic

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6858033d4408832ea41e2fe275601c9f