### PR TITLE
Improve timed refresh handling without end time

### DIFF
--- a/custom_components/simple_auto_cover/coordinator.py
+++ b/custom_components/simple_auto_cover/coordinator.py
@@ -158,15 +158,19 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         """Control state at end time."""
 
         now = dt.datetime.now()
+        time = None
         if self.end_time is not None:
             time = self.end_time
         if self.end_time_entity is not None:
             time = get_safe_state(self.hass, self.end_time_entity)
 
         self.logger.debug("Checking timed refresh. End time: %s, now: %s", time, now)
+        if time is None:
+            self.logger.debug("Timed refresh aborted: no end time configured")
+            return
 
         time_check = now - get_datetime_from_str(time)
-        if time is not None and (time_check <= dt.timedelta(seconds=1)):
+        if time_check <= dt.timedelta(seconds=1):
             self.timed_refresh = True
             self.logger.debug("Timed refresh triggered")
             await self.async_refresh()

--- a/tests/test_calculation.py
+++ b/tests/test_calculation.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import datetime as dt
+import types
 import pytest
 
 
@@ -44,6 +45,7 @@ class TestVerticalCover:
             "max_elevation": None,
             "distance": 1,
             "h_win": 2,
+            "logger": types.SimpleNamespace(debug=lambda *a, **kw: None),
         }
         defaults.update(kwargs)
         cover = DummyCover(**defaults)
@@ -66,6 +68,7 @@ def test_normal_cover_state_default(module):
             self.apply_min_position = False
             self.max_pos = 100
             self.min_pos = 0
+            self.logger = types.SimpleNamespace(debug=lambda *a, **kw: None)
 
         def calculate_percentage(self):
             return 80
@@ -83,6 +86,7 @@ def test_normal_cover_state_apply_max(module):
             self.max_pos = 50
             self.apply_min_position = False
             self.min_pos = 0
+            self.logger = types.SimpleNamespace(debug=lambda *a, **kw: None)
 
         def calculate_percentage(self):
             return 80

--- a/tests/test_calculation.py
+++ b/tests/test_calculation.py
@@ -45,7 +45,7 @@ class TestVerticalCover:
             "max_elevation": None,
             "distance": 1,
             "h_win": 2,
-            "logger": types.SimpleNamespace(debug=lambda *a, **kw: None),
+            "logger": types.SimpleNamespace(debug=lambda *a, **k: None),
         }
         if hasattr(
             calculation_module.AdaptiveVerticalCover,

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -32,6 +32,7 @@ def make_coordinator(module, cover_type="cover_blind"):
     coord._cover_type = cover_type
     coord.min_change = 10
     coord.time_threshold = 2
+    coord.logger = types.SimpleNamespace(debug=lambda *a, **kw: None)
     return coord, hass
 
 
@@ -83,3 +84,14 @@ def test_check_time_delta(module):
 
 def test_inverse_state(module):
     assert module.inverse_state(20) == 80
+
+
+def test_async_timed_refresh_without_end_time(module):
+    coord, hass = make_coordinator(module)
+    coord.end_time = None
+    coord.end_time_entity = None
+    coord.timed_refresh = False
+    import asyncio
+
+    asyncio.run(coord.async_timed_refresh(None))
+    assert coord.timed_refresh is False


### PR DESCRIPTION
## Summary
- avoid unbound `time` in `async_timed_refresh`
- skip timed refresh when no end time is defined
- stub loggers in tests
- test timed refresh with no end time

## Testing
- `pre-commit run --files custom_components/simple_auto_cover/coordinator.py tests/test_calculation.py tests/test_coordinator.py`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685809a142a0832e844269a48be90d2a