### PR TITLE
Use constant for cover type names

### DIFF
--- a/custom_components/simple_auto_cover/binary_sensor.py
+++ b/custom_components/simple_auto_cover/binary_sensor.py
@@ -15,7 +15,7 @@ from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import CONF_SENSOR_TYPE, DOMAIN
+from .const import CONF_SENSOR_TYPE, DOMAIN, COVER_TYPE_DISPLAY
 from .coordinator import AdaptiveDataUpdateCoordinator
 
 
@@ -70,11 +70,7 @@ class AdaptiveCoverBinarySensor(
     ) -> None:
         """Initialize the binary sensor."""
         super().__init__(coordinator=coordinator)
-        self.type = {
-            "cover_blind": "Vertical",
-            "cover_awning": "Horizontal",
-            "cover_tilt": "Tilt",
-        }
+        self.type = COVER_TYPE_DISPLAY
         self._key = key
         self._attr_translation_key = key
         self._name = config_entry.data["name"]

--- a/custom_components/simple_auto_cover/button.py
+++ b/custom_components/simple_auto_cover/button.py
@@ -11,7 +11,13 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import _LOGGER, CONF_ENTITIES, CONF_SENSOR_TYPE, DOMAIN
+from .const import (
+    _LOGGER,
+    CONF_ENTITIES,
+    CONF_SENSOR_TYPE,
+    DOMAIN,
+    COVER_TYPE_DISPLAY,
+)
 from .coordinator import AdaptiveDataUpdateCoordinator
 
 
@@ -56,11 +62,7 @@ class AdaptiveCoverButton(
     ) -> None:
         """Initialize the button."""
         super().__init__(coordinator=coordinator)
-        self.type = {
-            "cover_blind": "Vertical",
-            "cover_awning": "Horizontal",
-            "cover_tilt": "Tilt",
-        }
+        self.type = COVER_TYPE_DISPLAY
         self._name = config_entry.data["name"]
         self._device_name = self.type[config_entry.data[CONF_SENSOR_TYPE]]
         self._attr_unique_id = f"{unique_id}_{button_name}"

--- a/custom_components/simple_auto_cover/const.py
+++ b/custom_components/simple_auto_cover/const.py
@@ -72,3 +72,10 @@ class SensorType:
     BLIND = "cover_blind"
     AWNING = "cover_awning"
     TILT = "cover_tilt"
+
+# Human readable names for the available cover types
+COVER_TYPE_DISPLAY = {
+    SensorType.BLIND: "Vertical",
+    SensorType.AWNING: "Horizontal",
+    SensorType.TILT: "Tilt",
+}

--- a/custom_components/simple_auto_cover/sensor.py
+++ b/custom_components/simple_auto_cover/sensor.py
@@ -21,6 +21,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import (
     CONF_SENSOR_TYPE,
     DOMAIN,
+    COVER_TYPE_DISPLAY,
 )
 from .coordinator import AdaptiveDataUpdateCoordinator
 
@@ -87,11 +88,7 @@ class AdaptiveCoverSensorEntity(
     ) -> None:
         """Initialize simple_auto_cover Sensor."""
         super().__init__(coordinator=coordinator)
-        self.type = {
-            "cover_blind": "Vertical",
-            "cover_awning": "Horizontal",
-            "cover_tilt": "Tilt",
-        }
+        self.type = COVER_TYPE_DISPLAY
         self.coordinator = coordinator
         self.data = self.coordinator.data
         self._sensor_name = "Cover Position"
@@ -154,11 +151,7 @@ class AdaptiveCoverTimeSensorEntity(
     ) -> None:
         """Initialize simple_auto_cover Sensor."""
         super().__init__(coordinator=coordinator)
-        self.type = {
-            "cover_blind": "Vertical",
-            "cover_awning": "Horizontal",
-            "cover_tilt": "Tilt",
-        }
+        self.type = COVER_TYPE_DISPLAY
         self._attr_icon = icon
         self.key = key
         self.coordinator = coordinator
@@ -217,11 +210,7 @@ class AdaptiveCoverControlSensorEntity(
     ) -> None:
         """Initialize simple_auto_cover Sensor."""
         super().__init__(coordinator=coordinator)
-        self.type = {
-            "cover_blind": "Vertical",
-            "cover_awning": "Horizontal",
-            "cover_tilt": "Tilt",
-        }
+        self.type = COVER_TYPE_DISPLAY
         self.coordinator = coordinator
         self.data = self.coordinator.data
         self._sensor_name = "Control Method"

--- a/custom_components/simple_auto_cover/switch.py
+++ b/custom_components/simple_auto_cover/switch.py
@@ -17,6 +17,7 @@ from .const import (
     CONF_ENTITIES,
     CONF_SENSOR_TYPE,
     DOMAIN,
+    COVER_TYPE_DISPLAY,
 )
 from .coordinator import AdaptiveDataUpdateCoordinator
 
@@ -75,11 +76,7 @@ class AdaptiveCoverSwitch(
     ) -> None:
         """Initialize the switch."""
         super().__init__(coordinator=coordinator)
-        self.type = {
-            "cover_blind": "Vertical",
-            "cover_awning": "Horizontal",
-            "cover_tilt": "Tilt",
-        }
+        self.type = COVER_TYPE_DISPLAY
         self._name = config_entry.data["name"]
         self._state: bool | None = None
         self._key = key


### PR DESCRIPTION
## Summary
- define `COVER_TYPE_DISPLAY` in `const.py`
- replace duplicate dictionaries in sensor, switch, binary sensor, and button modules with the new constant

## Testing
- `ruff check custom_components/simple_auto_cover/const.py custom_components/simple_auto_cover/sensor.py custom_components/simple_auto_cover/switch.py custom_components/simple_auto_cover/binary_sensor.py custom_components/simple_auto_cover/button.py`
- `pytest -q` *(fails: AdaptiveVerticalCover.__init__() missing positional argument 'logger')*

------
https://chatgpt.com/codex/tasks/task_e_68580fda4b30832ea75f8a49b7e14604