### PR TITLE
Fix lint issues in tests

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,3 +1,5 @@
+"""Fixtures and helper utilities for the test suite."""
+
 import sys
 import types
 import math
@@ -23,7 +25,7 @@ numpy_stub.rad2deg = math.degrees
 numpy_stub.arctan = math.atan
 numpy_stub.sqrt = math.sqrt
 numpy_stub.where = lambda cond, a, b: a if cond else b
-numpy_stub.isscalar = lambda obj: isinstance(obj, (int, float, complex))
+numpy_stub.isscalar = lambda obj: isinstance(obj, int | float | complex)
 sys.modules.setdefault("numpy", numpy_stub)
 
 pandas_stub = types.ModuleType("pandas")
@@ -46,6 +48,7 @@ sys.modules.setdefault("dateutil.parser", parser_stub)
 # ---------------------------------------------------------------------------
 
 def import_module(path: str, name: str):
+    """Load ``name`` from the specified ``path``."""
     root = Path(__file__).resolve().parents[1]
     if str(root) not in sys.path:
         sys.path.insert(0, str(root))
@@ -62,6 +65,7 @@ def import_module(path: str, name: str):
 
 @pytest.fixture
 def calculation():
+    """Provide the calculation module used in tests."""
     return import_module(
         "custom_components/simple_auto_cover/calculation.py",
         "custom_components.simple_auto_cover.calculation",
@@ -70,6 +74,7 @@ def calculation():
 
 @pytest.fixture
 def coordinator():
+    """Provide the coordinator module used in tests."""
     return import_module(
         "custom_components/simple_auto_cover/coordinator.py",
         "custom_components.simple_auto_cover.coordinator",

--- a/tests/test_calculation.py
+++ b/tests/test_calculation.py
@@ -2,19 +2,22 @@
 
 from __future__ import annotations
 
-import datetime as dt
 import types
 import pytest
 
 
 @pytest.fixture
 def module(calculation):
+    """Return the calculation module under test."""
     return calculation
 
 
 class TestVerticalCover:
+    """Helper class for AdaptiveVerticalCover test instances."""
+
     @staticmethod
     def make_cover(calculation_module, **kwargs):
+        """Create a dummy ``AdaptiveVerticalCover`` instance."""
         class DummyCover(calculation_module.AdaptiveVerticalCover):
             __test__ = False
 
@@ -59,12 +62,14 @@ class TestVerticalCover:
 
 
 def test_vertical_cover_calculation(module):
+    """Test calculation of the adaptive vertical cover."""
     cover = TestVerticalCover.make_cover(module)
     assert cover.calculate_position() == pytest.approx(1)
     assert cover.calculate_percentage() == 50
 
 
 def test_normal_cover_state_default(module):
+    """Test the default state when no max position is applied."""
     class DummyCover:
         def __init__(self):
             self.direct_sun_valid = False
@@ -83,6 +88,7 @@ def test_normal_cover_state_default(module):
 
 
 def test_normal_cover_state_apply_max(module):
+    """Test the state when the max position should be applied."""
     class DummyCover:
         def __init__(self):
             self.direct_sun_valid = True

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -9,22 +9,30 @@ import pytest
 
 @pytest.fixture
 def module(coordinator):
+    """Return the coordinator module under test."""
     return coordinator
 
 
 class DummyStates(dict):
+    """Minimal stand-in for :class:`homeassistant.core.States`."""
+
     def get(self, entity_id):
+        """Return the entity state if present."""
         return super().get(entity_id)
 
 
 class HomeAssistant:
+    """Simplified Home Assistant instance for tests."""
+
     def __init__(self, config_dir: str = "/tmp") -> None:
+        """Initialize the dummy instance."""
         self.states = DummyStates()
         self.services = types.SimpleNamespace(async_call=lambda *a, **kw: None)
         self.config = types.SimpleNamespace(time_zone="UTC")
 
 
 def make_coordinator(module, cover_type="cover_blind"):
+    """Instantiate a coordinator and its surrounding fixtures."""
     hass = HomeAssistant()
     coord = module.AdaptiveDataUpdateCoordinator.__new__(module.AdaptiveDataUpdateCoordinator)
     coord.hass = hass
@@ -38,6 +46,7 @@ def make_coordinator(module, cover_type="cover_blind"):
 
 
 def test_get_current_position(module):
+    """Verify that the current position is read correctly."""
     coord, hass = make_coordinator(module, "cover_blind")
     hass.states["cover.test"] = module.State("cover.test", "open", {"current_position": 40})
     assert coord._get_current_position("cover.test") == 40
@@ -48,6 +57,7 @@ def test_get_current_position(module):
 
 
 def test_check_position(module):
+    """Ensure the coordinator detects position changes."""
     coord, hass = make_coordinator(module)
     hass.states["cover.test"] = module.State("cover.test", "open", {"current_position": 40})
     assert coord.check_position("cover.test", 50) is True
@@ -58,6 +68,7 @@ def test_check_position(module):
 
 
 def test_check_position_delta(module):
+    """Check that large enough deltas trigger updates."""
     coord, hass = make_coordinator(module)
     hass.states["cover.test"] = module.State("cover.test", "open", {"current_position": 40})
     options = {module.CONF_SUNSET_POS: 0, module.CONF_DEFAULT_HEIGHT: 50}
@@ -71,6 +82,7 @@ def test_check_position_delta(module):
 
 
 def test_check_time_delta(module):
+    """Check that updates occur after the time threshold."""
     coord, hass = make_coordinator(module)
     past = dt.datetime.now(dt.UTC) - dt.timedelta(minutes=3)
     hass.states["cover.test"] = module.State("cover.test", "open", last_updated=past)
@@ -84,10 +96,12 @@ def test_check_time_delta(module):
 
 
 def test_inverse_state(module):
+    """Test inversion utility for tilt covers."""
     assert module.inverse_state(20) == 80
 
 
 def test_async_timed_refresh_without_end_time(module):
+    """Execute ``async_timed_refresh`` when no end time is set."""
     coord, hass = make_coordinator(module)
     coord.end_time = None
     coord.end_time_entity = None

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -5,7 +5,6 @@ from __future__ import annotations
 import importlib
 import sys
 from pathlib import Path
-import types
 import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
@@ -25,30 +24,42 @@ def test_import_success():
 
 
 class DummyConfigEntries:
+    """Mock of Home Assistant's config entries helper."""
+
     def __init__(self):
+        """Initialize storage for recorded actions."""
         self.forwarded = []
         self.unloaded = []
         self.reloaded = None
 
     async def async_forward_entry_setups(self, entry, platforms):
+        """Record forwarded setups."""
         self.forwarded.append((entry, platforms))
 
     async def async_unload_platforms(self, entry, platforms):
+        """Record unloaded platforms."""
         self.unloaded.append((entry, platforms))
         return True
 
     async def async_reload(self, entry_id):
+        """Record a reload request."""
         self.reloaded = entry_id
 
 
 class DummyHass:
+    """Very small subset of :class:`homeassistant.core.HomeAssistant`."""
+
     def __init__(self):
+        """Initialize the dummy Home Assistant object."""
         self.config_entries = DummyConfigEntries()
         self.data = {}
 
 
 class DummyEntry:
+    """Mimic a config entry object."""
+
     def __init__(self, entry_id="1", data=None, options=None):
+        """Create a new dummy entry."""
         self.entry_id = entry_id
         self.data = data or {}
         self.options = options or {}
@@ -56,25 +67,33 @@ class DummyEntry:
         self.unload_callbacks = []
 
     def async_on_unload(self, callback):
+        """Register a callback to run on unload."""
         self.unload_callbacks.append(callback)
 
     def add_update_listener(self, listener):
+        """Track listener registration."""
         self.update_listeners.append(listener)
         return listener
 
 
 class DummyCoordinator:
+    """Stubbed coordinator used during integration tests."""
+
     def __init__(self, hass):
+        """Initialize the dummy coordinator."""
         self.hass = hass
         self.first_refresh = False
 
     async def async_config_entry_first_refresh(self):
+        """Simulate the first refresh logic."""
         self.first_refresh = True
 
     async def async_check_entity_state_change(self, *args, **kwargs):
+        """Mock handler for entity state changes."""
         pass
 
     async def async_check_cover_state_change(self, *args, **kwargs):
+        """Mock handler for cover state changes."""
         pass
 
 


### PR DESCRIPTION
## Summary
- add missing docstrings in test helpers and fixtures
- update `isinstance` call to use union syntax
- document dummy coordinator and helper classes
- ensure lint and tests pass

## Testing
- `scripts/lint`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685818338570832e9d706ff4a512bc49