### PR TITLE
Use Enum for sensor type

### DIFF
--- a/custom_components/simple_auto_cover/config_flow.py
+++ b/custom_components/simple_auto_cover/config_flow.py
@@ -434,13 +434,13 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
 
     async def async_step_update(self, user_input: dict[str, Any] | None = None):
         """Create entry."""
-        type = {
-            "cover_blind": "Vertical",
-            "cover_awning": "Horizontal",
-            "cover_tilt": "Tilt",
+        type_map = {
+            SensorType.BLIND: "Vertical",
+            SensorType.AWNING: "Horizontal",
+            SensorType.TILT: "Tilt",
         }
         return self.async_create_entry(
-            title=f"{type[self.type_blind]} {self.config['name']}",
+            title=f"{type_map[self.type_blind]} {self.config['name']}",
             data={
                 "name": self.config["name"],
                 CONF_SENSOR_TYPE: self.type_blind,

--- a/custom_components/simple_auto_cover/const.py
+++ b/custom_components/simple_auto_cover/const.py
@@ -62,7 +62,10 @@ STRATEGY_MODE_BASIC = "basic"
 STRATEGY_MODES = [STRATEGY_MODE_BASIC]
 
 
-class SensorType:
+from enum import Enum
+
+
+class SensorType(str, Enum):
     """Possible modes for a number selector."""
 
     BLIND = "cover_blind"

--- a/custom_components/simple_auto_cover/coordinator.py
+++ b/custom_components/simple_auto_cover/coordinator.py
@@ -82,6 +82,7 @@ from .const import (
     CONF_TILT_MODE,
     DOMAIN,
     LOGGER,
+    SensorType,
 )
 from .helpers import get_datetime_from_str, get_last_updated, get_safe_state
 
@@ -114,7 +115,9 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
 
         self.logger = ConfigContextAdapter(_LOGGER)
         self.logger.set_config_name(self.config_entry.data.get("name"))
-        self._cover_type = self.config_entry.data.get("sensor_type")
+        self._cover_type: SensorType = SensorType(
+            self.config_entry.data.get("sensor_type", SensorType.BLIND)
+        )
         self._inverse_state = self.config_entry.options.get(CONF_INVERSE_STATE, False)
         self._use_interpolation = self.config_entry.options.get(CONF_INTERP, False)
         self._track_end_time = self.config_entry.options.get(CONF_RETURN_SUNSET)
@@ -223,7 +226,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         if self.wait_for_target.get(entity_id):
             position = event.new_state.attributes.get(
                 "current_position"
-                if self._cover_type != "cover_tilt"
+                if self._cover_type != SensorType.TILT
                 else "current_tilt_position"
             )
             if position == self.target_call.get(entity_id):
@@ -423,7 +426,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             service_data = {}
             service_data[ATTR_ENTITY_ID] = entity
 
-            if self._cover_type == "cover_tilt":
+            if self._cover_type == SensorType.TILT:
                 service = SERVICE_SET_COVER_TILT_POSITION
                 service_data[ATTR_TILT_POSITION] = state
             else:
@@ -466,7 +469,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
 
     def get_blind_data(self, options):
         """Assign correct class for type of blind."""
-        if self._cover_type == "cover_blind":
+        if self._cover_type == SensorType.BLIND:
             cover_data = AdaptiveVerticalCover(
                 self.hass,
                 self.logger,
@@ -474,7 +477,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                 *self.common_data(options),
                 *self.vertical_data(options),
             )
-        if self._cover_type == "cover_awning":
+        if self._cover_type == SensorType.AWNING:
             cover_data = AdaptiveHorizontalCover(
                 self.hass,
                 self.logger,
@@ -483,7 +486,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                 *self.vertical_data(options),
                 *self.horizontal_data(options),
             )
-        if self._cover_type == "cover_tilt":
+        if self._cover_type == SensorType.TILT:
             cover_data = AdaptiveTiltCover(
                 self.hass,
                 self.logger,
@@ -553,7 +556,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
 
     def _get_current_position(self, entity) -> int | None:
         """Get current position of cover."""
-        if self._cover_type == "cover_tilt":
+        if self._cover_type == SensorType.TILT:
             return state_attr(self.hass, entity, "current_tilt_position")
         return state_attr(self.hass, entity, "current_position")
 
@@ -745,7 +748,7 @@ class AdaptiveCoverManager:
         self,
         states_data,
         our_state,
-        blind_type,
+        blind_type: SensorType,
         allow_reset,
         wait_target_call,
         manual_threshold,
@@ -762,7 +765,7 @@ class AdaptiveCoverManager:
 
         new_state = event.new_state
 
-        if blind_type == "cover_tilt":
+        if blind_type == SensorType.TILT:
             new_position = new_state.attributes.get("current_tilt_position")
         else:
             new_position = new_state.attributes.get("current_position")

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -24,7 +24,9 @@ class HomeAssistant:
         self.config = types.SimpleNamespace(time_zone="UTC")
 
 
-def make_coordinator(module, cover_type="cover_blind"):
+def make_coordinator(module, cover_type=None):
+    if cover_type is None:
+        cover_type = module.SensorType.BLIND
     hass = HomeAssistant()
     coord = module.AdaptiveDataUpdateCoordinator.__new__(module.AdaptiveDataUpdateCoordinator)
     coord.hass = hass
@@ -38,11 +40,11 @@ def make_coordinator(module, cover_type="cover_blind"):
 
 
 def test_get_current_position(module):
-    coord, hass = make_coordinator(module, "cover_blind")
+    coord, hass = make_coordinator(module, module.SensorType.BLIND)
     hass.states["cover.test"] = module.State("cover.test", "open", {"current_position": 40})
     assert coord._get_current_position("cover.test") == 40
 
-    coord._cover_type = "cover_tilt"
+    coord._cover_type = module.SensorType.TILT
     hass.states["cover.test"] = module.State("cover.test", "open", {"current_tilt_position": 30})
     assert coord._get_current_position("cover.test") == 30
 


### PR DESCRIPTION
## Summary
- make `SensorType` a `str` `Enum`
- adjust coordinator logic to use new enum values
- update config flow accordingly
- fix tests

## Testing
- `pre-commit run --files custom_components/simple_auto_cover/const.py custom_components/simple_auto_cover/coordinator.py custom_components/simple_auto_cover/config_flow.py tests/test_coordinator.py` *(fails: unable to access 'https://github.com/astral-sh/ruff-pre-commit/' because the environment blocks network access)*
- `scripts/test`

------
https://chatgpt.com/codex/tasks/task_e_68581a4c9b3c832ea3a87ee8d3d58cea