### PR TITLE
Fix event loop retrieval

### DIFF
--- a/custom_components/simple_auto_cover/coordinator.py
+++ b/custom_components/simple_auto_cover/coordinator.py
@@ -270,7 +270,6 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         # Update manager with covers
         self._update_manager_and_covers()
 
-
         self.logger.debug("Control method is %s", self.control_method)
 
         # calculate the state of the cover
@@ -310,7 +309,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             or dt.datetime.now(pytz.UTC).date() != self._sun_start_time.date()
         ):
             self.logger.debug("Calculating solar times")
-            loop = asyncio.get_event_loop()
+            loop = asyncio.get_running_loop()
             start, end = await loop.run_in_executor(None, normal_cover.solar_times)
             self._sun_start_time = start
             self._sun_end_time = end
@@ -704,7 +703,6 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                 state = 100
         return state
 
-
     @property
     def control_toggle(self):
         """Toggle automation."""
@@ -722,7 +720,6 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
     @manual_toggle.setter
     def manual_toggle(self, value):
         self._manual_toggle = value
-
 
 
 class AdaptiveCoverManager:


### PR DESCRIPTION
## Summary
- use `asyncio.get_running_loop` when calculating solar times

## Testing
- `ruff check custom_components/simple_auto_cover/coordinator.py --fix`
- `ruff format custom_components/simple_auto_cover/coordinator.py`
- `pytest -q`
- *(fails: `pre-commit` hooks due to missing network access)*

------
https://chatgpt.com/codex/tasks/task_e_68581a341410832eb2078e6a8fdf6c14