### PR TITLE
Fix config flow schema usage

### DIFF
--- a/custom_components/simple_auto_cover/config_flow.py
+++ b/custom_components/simple_auto_cover/config_flow.py
@@ -301,7 +301,7 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
                 if user_input[CONF_MAX_ELEVATION] <= user_input[CONF_MIN_ELEVATION]:
                     return self.async_show_form(
                         step_id="vertical",
-                        data_schema=VERTICAL_OPTIONS.schema,
+                        data_schema=VERTICAL_OPTIONS,
                         errors={
                             CONF_MAX_ELEVATION: "Must be greater than 'Minimal Elevation'"
                         },
@@ -314,7 +314,7 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
             return await self.async_step_automation()
         return self.async_show_form(
             step_id="vertical",
-            data_schema=VERTICAL_OPTIONS.schema,
+            data_schema=VERTICAL_OPTIONS,
         )
 
     async def async_step_horizontal(self, user_input: dict[str, Any] | None = None):
@@ -328,7 +328,7 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
                 if user_input[CONF_MAX_ELEVATION] <= user_input[CONF_MIN_ELEVATION]:
                     return self.async_show_form(
                         step_id="horizontal",
-                        data_schema=HORIZONTAL_OPTIONS.schema,
+                        data_schema=HORIZONTAL_OPTIONS,
                         errors={
                             CONF_MAX_ELEVATION: "Must be greater than 'Minimal Elevation'"
                         },
@@ -341,7 +341,7 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
             return await self.async_step_automation()
         return self.async_show_form(
             step_id="horizontal",
-            data_schema=HORIZONTAL_OPTIONS.schema,
+            data_schema=HORIZONTAL_OPTIONS,
         )
 
     async def async_step_tilt(self, user_input: dict[str, Any] | None = None):
@@ -355,7 +355,7 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
                 if user_input[CONF_MAX_ELEVATION] <= user_input[CONF_MIN_ELEVATION]:
                     return self.async_show_form(
                         step_id="tilt",
-                        data_schema=TILT_OPTIONS.schema,
+                        data_schema=TILT_OPTIONS,
                         errors={
                             CONF_MAX_ELEVATION: "Must be greater than 'Minimal Elevation'"
                         },
@@ -366,7 +366,7 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
             if self.config[CONF_ENABLE_BLIND_SPOT]:
                 return await self.async_step_blind_spot()
             return await self.async_step_automation()
-        return self.async_show_form(step_id="tilt", data_schema=TILT_OPTIONS.schema)
+        return self.async_show_form(step_id="tilt", data_schema=TILT_OPTIONS)
 
     async def async_step_interp(self, user_input: dict[str, Any] | None = None):
         """Show interpolation options."""

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,0 +1,23 @@
+import importlib
+import sys
+from pathlib import Path
+import pytest
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+for mod in ["numpy", "pandas", "pytz", "dateutil", "dateutil.parser"]:
+    sys.modules.pop(mod, None)
+importlib.invalidate_caches()
+
+try:
+    import custom_components.simple_auto_cover.config_flow as cf
+except Exception as exc:
+    pytest.fail(f"Failed to import config flow: {exc}")
+
+
+@pytest.mark.asyncio
+async def test_vertical_schema_callable():
+    handler = cf.ConfigFlowHandler()
+    result = await handler.async_step_vertical(None)
+    schema = result["data_schema"]
+    assert callable(schema)
+    assert isinstance(schema({}), dict)


### PR DESCRIPTION
## Summary
- add regression test for config flow schemas
- fix config flow to pass the vol.Schema objects instead of the raw dicts

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_685824ca39c0832e9596256411788706