### PR TITLE
Refactor cover manager to new module

### DIFF
--- a/custom_components/simple_auto_cover/coordinator.py
+++ b/custom_components/simple_auto_cover/coordinator.py
@@ -84,6 +84,7 @@ from .const import (
     LOGGER,
 )
 from .helpers import get_datetime_from_str, get_last_updated, get_safe_state
+from .cover_manager import AdaptiveCoverManager
 
 
 @dataclass
@@ -725,127 +726,6 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
 
 
 
-class AdaptiveCoverManager:
-    """Track position changes."""
-
-    def __init__(self, reset_duration: dict[str:int], logger) -> None:
-        """Initialize the AdaptiveCoverManager."""
-        self.covers: set[str] = set()
-
-        self.manual_control: dict[str, bool] = {}
-        self.manual_control_time: dict[str, dt.datetime] = {}
-        self.reset_duration = dt.timedelta(**reset_duration)
-        self.logger = logger
-
-    def add_covers(self, entity):
-        """Update set with entities."""
-        self.covers.update(entity)
-
-    def handle_state_change(
-        self,
-        states_data,
-        our_state,
-        blind_type,
-        allow_reset,
-        wait_target_call,
-        manual_threshold,
-    ):
-        """Process state change event."""
-        event = states_data
-        if event is None:
-            return
-        entity_id = event.entity_id
-        if entity_id not in self.covers:
-            return
-        if wait_target_call.get(entity_id):
-            return
-
-        new_state = event.new_state
-
-        if blind_type == "cover_tilt":
-            new_position = new_state.attributes.get("current_tilt_position")
-        else:
-            new_position = new_state.attributes.get("current_position")
-
-        if new_position != our_state:
-            if (
-                manual_threshold is not None
-                and abs(our_state - new_position) < manual_threshold
-            ):
-                self.logger.debug(
-                    "Position change is less than threshold %s for %s",
-                    manual_threshold,
-                    entity_id,
-                )
-                return
-            self.logger.debug(
-                "Manual change detected for %s. Our state: %s, new state: %s",
-                entity_id,
-                our_state,
-                new_position,
-            )
-            self.logger.debug(
-                "Set manual control for %s, for at least %s seconds, reset_allowed: %s",
-                entity_id,
-                self.reset_duration.total_seconds(),
-                allow_reset,
-            )
-            self.mark_manual_control(entity_id)
-            self.set_last_updated(entity_id, new_state, allow_reset)
-
-    def set_last_updated(self, entity_id, new_state, allow_reset):
-        """Set last updated time for manual control."""
-        if entity_id not in self.manual_control_time or allow_reset:
-            last_updated = new_state.last_updated
-            self.manual_control_time[entity_id] = last_updated
-            self.logger.debug(
-                "Updating last updated for manual control to %s for %s. Allow reset:%s",
-                last_updated,
-                entity_id,
-                allow_reset,
-            )
-        elif not allow_reset:
-            self.logger.debug(
-                "Already manual control time specified for %s, reset is not allowed by user setting:%s",
-                entity_id,
-                allow_reset,
-            )
-
-    def mark_manual_control(self, cover: str) -> None:
-        """Mark cover as under manual control."""
-        self.manual_control[cover] = True
-
-    async def reset_if_needed(self):
-        """Reset manual control state of the covers."""
-        current_time = dt.datetime.now(dt.UTC)
-        manual_control_time_copy = dict(self.manual_control_time)
-        for entity_id, last_updated in manual_control_time_copy.items():
-            if current_time - last_updated > self.reset_duration:
-                self.logger.debug(
-                    "Resetting manual override for %s, because duration has elapsed",
-                    entity_id,
-                )
-                self.reset(entity_id)
-
-    def reset(self, entity_id):
-        """Reset manual control for a cover."""
-        self.manual_control[entity_id] = False
-        self.manual_control_time.pop(entity_id, None)
-        self.logger.debug("Reset manual override for %s", entity_id)
-
-    def is_cover_manual(self, entity_id):
-        """Check if a cover is under manual control."""
-        return self.manual_control.get(entity_id, False)
-
-    @property
-    def binary_cover_manual(self):
-        """Check if any cover is under manual control."""
-        return any(value for value in self.manual_control.values())
-
-    @property
-    def manual_controlled(self):
-        """Get the list of covers under manual control."""
-        return [k for k, v in self.manual_control.items() if v]
 
 
 def inverse_state(state: int) -> int:

--- a/custom_components/simple_auto_cover/cover_manager.py
+++ b/custom_components/simple_auto_cover/cover_manager.py
@@ -1,0 +1,129 @@
+"""Manage manual control state for covers."""
+
+from __future__ import annotations
+
+import datetime as dt
+
+
+class AdaptiveCoverManager:
+    """Track position changes."""
+
+    def __init__(self, reset_duration: dict[str, int], logger) -> None:
+        """Initialize the AdaptiveCoverManager."""
+        self.covers: set[str] = set()
+
+        self.manual_control: dict[str, bool] = {}
+        self.manual_control_time: dict[str, dt.datetime] = {}
+        self.reset_duration = dt.timedelta(**reset_duration)
+        self.logger = logger
+
+    def add_covers(self, entity) -> None:
+        """Update set with entities."""
+        self.covers.update(entity)
+
+    def handle_state_change(
+        self,
+        states_data,
+        our_state,
+        blind_type,
+        allow_reset,
+        wait_target_call,
+        manual_threshold,
+    ) -> None:
+        """Process state change event."""
+        event = states_data
+        if event is None:
+            return
+        entity_id = event.entity_id
+        if entity_id not in self.covers:
+            return
+        if wait_target_call.get(entity_id):
+            return
+
+        new_state = event.new_state
+
+        if blind_type == "cover_tilt":
+            new_position = new_state.attributes.get("current_tilt_position")
+        else:
+            new_position = new_state.attributes.get("current_position")
+
+        if new_position != our_state:
+            if (
+                manual_threshold is not None
+                and abs(our_state - new_position) < manual_threshold
+            ):
+                self.logger.debug(
+                    "Position change is less than threshold %s for %s",
+                    manual_threshold,
+                    entity_id,
+                )
+                return
+            self.logger.debug(
+                "Manual change detected for %s. Our state: %s, new state: %s",
+                entity_id,
+                our_state,
+                new_position,
+            )
+            self.logger.debug(
+                "Set manual control for %s, for at least %s seconds, reset_allowed: %s",
+                entity_id,
+                self.reset_duration.total_seconds(),
+                allow_reset,
+            )
+            self.mark_manual_control(entity_id)
+            self.set_last_updated(entity_id, new_state, allow_reset)
+
+    def set_last_updated(self, entity_id, new_state, allow_reset) -> None:
+        """Set last updated time for manual control."""
+        if entity_id not in self.manual_control_time or allow_reset:
+            last_updated = new_state.last_updated
+            self.manual_control_time[entity_id] = last_updated
+            self.logger.debug(
+                "Updating last updated for manual control to %s for %s. Allow reset:%s",
+                last_updated,
+                entity_id,
+                allow_reset,
+            )
+        elif not allow_reset:
+            self.logger.debug(
+                "Already manual control time specified for %s, reset is not allowed by user setting:%s",
+                entity_id,
+                allow_reset,
+            )
+
+    def mark_manual_control(self, cover: str) -> None:
+        """Mark cover as under manual control."""
+        self.manual_control[cover] = True
+
+    async def reset_if_needed(self) -> None:
+        """Reset manual control state of the covers."""
+        current_time = dt.datetime.now(dt.UTC)
+        manual_control_time_copy = dict(self.manual_control_time)
+        for entity_id, last_updated in manual_control_time_copy.items():
+            if current_time - last_updated > self.reset_duration:
+                self.logger.debug(
+                    "Resetting manual override for %s, because duration has elapsed",
+                    entity_id,
+                )
+                self.reset(entity_id)
+
+    def reset(self, entity_id) -> None:
+        """Reset manual control for a cover."""
+        self.manual_control[entity_id] = False
+        self.manual_control_time.pop(entity_id, None)
+        self.logger.debug("Reset manual override for %s", entity_id)
+
+    def is_cover_manual(self, entity_id):
+        """Check if a cover is under manual control."""
+        return self.manual_control.get(entity_id, False)
+
+    @property
+    def binary_cover_manual(self) -> bool:
+        """Check if any cover is under manual control."""
+        return any(value for value in self.manual_control.values())
+
+    @property
+    def manual_controlled(self) -> list[str]:
+        """Get the list of covers under manual control."""
+        return [k for k, v in self.manual_control.items() if v]
+

--- a/tests/test_cover_manager.py
+++ b/tests/test_cover_manager.py
@@ -1,0 +1,82 @@
+"""Tests for AdaptiveCoverManager."""
+
+from __future__ import annotations
+
+import datetime as dt
+import types
+
+import pytest
+
+
+@pytest.fixture
+def manager_module():
+    from tests.conftest import import_module
+
+    return import_module(
+        "custom_components/simple_auto_cover/cover_manager.py",
+        "custom_components.simple_auto_cover.cover_manager",
+    )
+
+
+@pytest.fixture
+def state_data_class(coordinator):
+    return coordinator.StateChangedData
+
+
+def make_manager(manager_module, seconds=30):
+    logger = types.SimpleNamespace(debug=lambda *a, **k: None)
+    return manager_module.AdaptiveCoverManager({"seconds": seconds}, logger)
+
+
+def make_state(entity_id: str, position: int, cover_type="cover"):
+    from homeassistant.core import State
+
+    attr = {
+        "current_tilt_position"
+        if cover_type == "cover_tilt"
+        else "current_position": position
+    }
+    return State(entity_id, "open", attr, last_updated=dt.datetime.now(dt.UTC))
+
+
+def test_add_and_basic_properties(manager_module):
+    manager = make_manager(manager_module)
+    manager.add_covers({"cover.one", "cover.two"})
+    assert manager.covers == {"cover.one", "cover.two"}
+    manager.mark_manual_control("cover.one")
+    assert manager.is_cover_manual("cover.one") is True
+    assert manager.binary_cover_manual is True
+    assert manager.manual_controlled == ["cover.one"]
+
+
+def test_handle_state_change_marks_manual(manager_module, state_data_class):
+    manager = make_manager(manager_module)
+    manager.add_covers({"cover.test"})
+    our_state = 10
+    event = state_data_class("cover.test", None, make_state("cover.test", 50))
+    manager.handle_state_change(event, our_state, "cover", True, {}, None)
+    assert manager.is_cover_manual("cover.test") is True
+    assert "cover.test" in manager.manual_control_time
+
+
+def test_handle_state_change_threshold(manager_module, state_data_class):
+    manager = make_manager(manager_module)
+    manager.add_covers({"cover.test"})
+    our_state = 10
+    event = state_data_class("cover.test", None, make_state("cover.test", 12))
+    manager.handle_state_change(event, our_state, "cover", True, {}, 5)
+    assert manager.is_cover_manual("cover.test") is False
+
+
+def test_reset_if_needed(manager_module, state_data_class):
+    manager = make_manager(manager_module, seconds=0)
+    manager.add_covers({"cover.test"})
+    past_state = make_state("cover.test", 50)
+    past_state.last_updated = dt.datetime.now(dt.UTC) - dt.timedelta(seconds=1)
+    event = state_data_class("cover.test", None, past_state)
+    manager.handle_state_change(event, 10, "cover", True, {}, None)
+    assert manager.is_cover_manual("cover.test")
+    import asyncio
+
+    asyncio.run(manager.reset_if_needed())
+    assert manager.is_cover_manual("cover.test") is False


### PR DESCRIPTION
## Summary
- extract `AdaptiveCoverManager` into `cover_manager.py`
- update coordinator to import from new module
- add tests for the `AdaptiveCoverManager`

## Testing
- `pytest -q`
- `ruff check` *(fails: D103)*

------
https://chatgpt.com/codex/tasks/task_e_68581a5bdb94832e84beea499cda3c58