### PR TITLE
Fix missing docstrings in tests

### DIFF
--- a/tests/test_sun.py
+++ b/tests/test_sun.py
@@ -1,3 +1,7 @@
+"""Tests for solar calculations in :mod:`sun`."""
+
+from __future__ import annotations
+
 import types
 import datetime as dt
 
@@ -5,9 +9,9 @@ import custom_components.simple_auto_cover.sun as sun
 
 
 def test_solar_azimuth_and_elevation(monkeypatch):
+    """Verify solar azimuth and elevation results for ``SunData``."""
     times = [
-        dt.datetime(2025, 1, 1, 0, 0) + dt.timedelta(minutes=5 * i)
-        for i in range(3)
+        dt.datetime(2025, 1, 1, 0, 0) + dt.timedelta(minutes=5 * i) for i in range(3)
     ]
 
     az_calls = []


### PR DESCRIPTION
## Summary
- add a module docstring for tests/test_sun.py
- document the solar azimuth/elevation test

## Testing
- `ruff check tests/test_sun.py`
- `ruff format --check tests/test_sun.py`
- `pytest tests/test_sun.py -q` *(fails: ModuleNotFoundError)*

------
https://chatgpt.com/codex/tasks/task_e_68582c07f07c832e8be53b3c54863ed9