### PR TITLE
Fix variable name in async_step_update

### DIFF
--- a/custom_components/simple_auto_cover/config_flow.py
+++ b/custom_components/simple_auto_cover/config_flow.py
@@ -430,13 +430,13 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
 
     async def async_step_update(self, user_input: dict[str, Any] | None = None):
         """Create entry."""
-        type = {
+        cover_label_map = {
             "cover_blind": "Vertical",
             "cover_awning": "Horizontal",
             "cover_tilt": "Tilt",
         }
         return self.async_create_entry(
-            title=f"{type[self.type_blind]} {self.config['name']}",
+            title=f"{cover_label_map[self.type_blind]} {self.config['name']}",
             data={
                 "name": self.config["name"],
                 CONF_SENSOR_TYPE: self.type_blind,


### PR DESCRIPTION
## Summary
- rename the local variable `type` to `cover_label_map` in `async_step_update`
- adjust config entry `title` formatting to use new variable

## Testing
- `scripts/test`

------
https://chatgpt.com/codex/tasks/task_e_68582dbf31e4832e836ab97310ff6709