### PR TITLE
Switch sensor types to enum

### DIFF
--- a/custom_components/simple_auto_cover/config_flow.py
+++ b/custom_components/simple_auto_cover/config_flow.py
@@ -57,6 +57,7 @@ from .const import (
     CONF_TILT_DISTANCE,
     CONF_TILT_MODE,
     DOMAIN,
+    COVER_TYPE_DISPLAY,
     SensorType,
     CONF_MIN_POSITION,
     CONF_ENABLE_MAX_POSITION,
@@ -430,13 +431,8 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
 
     async def async_step_update(self, user_input: dict[str, Any] | None = None):
         """Create entry."""
-        type = {
-            "cover_blind": "Vertical",
-            "cover_awning": "Horizontal",
-            "cover_tilt": "Tilt",
-        }
         return self.async_create_entry(
-            title=f"{type[self.type_blind]} {self.config['name']}",
+            title=f"{COVER_TYPE_DISPLAY[self.type_blind]} {self.config['name']}",
             data={
                 "name": self.config["name"],
                 CONF_SENSOR_TYPE: self.type_blind,

--- a/custom_components/simple_auto_cover/const.py
+++ b/custom_components/simple_auto_cover/const.py
@@ -62,8 +62,11 @@ STRATEGY_MODE_BASIC = "basic"
 STRATEGY_MODES = [STRATEGY_MODE_BASIC]
 
 
-class SensorType:
-    """Possible modes for a number selector."""
+from enum import StrEnum
+
+
+class SensorType(StrEnum):
+    """Supported cover sensor types."""
 
     BLIND = "cover_blind"
     AWNING = "cover_awning"

--- a/custom_components/simple_auto_cover/coordinator.py
+++ b/custom_components/simple_auto_cover/coordinator.py
@@ -82,6 +82,7 @@ from .const import (
     CONF_TILT_MODE,
     DOMAIN,
     LOGGER,
+    SensorType,
 )
 from .helpers import get_datetime_from_str, get_last_updated, get_safe_state
 from .cover_manager import AdaptiveCoverManager
@@ -224,7 +225,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         if self.wait_for_target.get(entity_id):
             position = event.new_state.attributes.get(
                 "current_position"
-                if self._cover_type != "cover_tilt"
+                if self._cover_type != SensorType.TILT
                 else "current_tilt_position"
             )
             if position == self.target_call.get(entity_id):
@@ -423,7 +424,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             service_data = {}
             service_data[ATTR_ENTITY_ID] = entity
 
-            if self._cover_type == "cover_tilt":
+            if self._cover_type == SensorType.TILT:
                 service = SERVICE_SET_COVER_TILT_POSITION
                 service_data[ATTR_TILT_POSITION] = state
             else:
@@ -466,7 +467,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
 
     def get_blind_data(self, options):
         """Assign correct class for type of blind."""
-        if self._cover_type == "cover_blind":
+        if self._cover_type == SensorType.BLIND:
             cover_data = AdaptiveVerticalCover(
                 self.hass,
                 self.logger,
@@ -474,7 +475,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                 *self.common_data(options),
                 *self.vertical_data(options),
             )
-        if self._cover_type == "cover_awning":
+        if self._cover_type == SensorType.AWNING:
             cover_data = AdaptiveHorizontalCover(
                 self.hass,
                 self.logger,
@@ -483,7 +484,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
                 *self.vertical_data(options),
                 *self.horizontal_data(options),
             )
-        if self._cover_type == "cover_tilt":
+        if self._cover_type == SensorType.TILT:
             cover_data = AdaptiveTiltCover(
                 self.hass,
                 self.logger,
@@ -553,7 +554,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
 
     def _get_current_position(self, entity) -> int | None:
         """Get current position of cover."""
-        if self._cover_type == "cover_tilt":
+        if self._cover_type == SensorType.TILT:
             return state_attr(self.hass, entity, "current_tilt_position")
         return state_attr(self.hass, entity, "current_position")
 

--- a/custom_components/simple_auto_cover/cover_manager.py
+++ b/custom_components/simple_auto_cover/cover_manager.py
@@ -4,6 +4,8 @@ from __future__ import annotations
 
 import datetime as dt
 
+from .const import SensorType
+
 
 class AdaptiveCoverManager:
     """Track position changes."""
@@ -42,7 +44,7 @@ class AdaptiveCoverManager:
 
         new_state = event.new_state
 
-        if blind_type == "cover_tilt":
+        if blind_type == SensorType.TILT:
             new_position = new_state.attributes.get("current_tilt_position")
         else:
             new_position = new_state.attributes.get("current_position")

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -6,6 +6,8 @@ import datetime as dt
 import types
 import pytest
 
+from custom_components.simple_auto_cover.const import SensorType
+
 
 @pytest.fixture
 def module(coordinator):
@@ -31,7 +33,7 @@ class HomeAssistant:
         self.config = types.SimpleNamespace(time_zone="UTC")
 
 
-def make_coordinator(module, cover_type="cover_blind"):
+def make_coordinator(module, cover_type: SensorType = SensorType.BLIND):
     """Instantiate a coordinator and its surrounding fixtures."""
     hass = HomeAssistant()
     coord = module.AdaptiveDataUpdateCoordinator.__new__(
@@ -49,13 +51,13 @@ def make_coordinator(module, cover_type="cover_blind"):
 
 def test_get_current_position(module):
     """Verify that the current position is read correctly."""
-    coord, hass = make_coordinator(module, "cover_blind")
+    coord, hass = make_coordinator(module, SensorType.BLIND)
     hass.states["cover.test"] = module.State(
         "cover.test", "open", {"current_position": 40}
     )
     assert coord._get_current_position("cover.test") == 40
 
-    coord._cover_type = "cover_tilt"
+    coord._cover_type = SensorType.TILT
     hass.states["cover.test"] = module.State(
         "cover.test", "open", {"current_tilt_position": 30}
     )

--- a/tests/test_cover_manager.py
+++ b/tests/test_cover_manager.py
@@ -7,6 +7,8 @@ import types
 
 import pytest
 
+from custom_components.simple_auto_cover.const import SensorType
+
 
 @pytest.fixture
 def manager_module():
@@ -28,12 +30,12 @@ def make_manager(manager_module, seconds=30):
     return manager_module.AdaptiveCoverManager({"seconds": seconds}, logger)
 
 
-def make_state(entity_id: str, position: int, cover_type="cover"):
+def make_state(entity_id: str, position: int, cover_type: str | SensorType = "cover"):
     from homeassistant.core import State
 
     attr = {
         "current_tilt_position"
-        if cover_type == "cover_tilt"
+        if cover_type == SensorType.TILT or cover_type == "cover_tilt"
         else "current_position": position
     }
     return State(entity_id, "open", attr, last_updated=dt.datetime.now(dt.UTC))
@@ -54,7 +56,7 @@ def test_handle_state_change_marks_manual(manager_module, state_data_class):
     manager.add_covers({"cover.test"})
     our_state = 10
     event = state_data_class("cover.test", None, make_state("cover.test", 50))
-    manager.handle_state_change(event, our_state, "cover", True, {}, None)
+    manager.handle_state_change(event, our_state, SensorType.BLIND, True, {}, None)
     assert manager.is_cover_manual("cover.test") is True
     assert "cover.test" in manager.manual_control_time
 
@@ -64,7 +66,7 @@ def test_handle_state_change_threshold(manager_module, state_data_class):
     manager.add_covers({"cover.test"})
     our_state = 10
     event = state_data_class("cover.test", None, make_state("cover.test", 12))
-    manager.handle_state_change(event, our_state, "cover", True, {}, 5)
+    manager.handle_state_change(event, our_state, SensorType.BLIND, True, {}, 5)
     assert manager.is_cover_manual("cover.test") is False
 
 
@@ -74,7 +76,7 @@ def test_reset_if_needed(manager_module, state_data_class):
     past_state = make_state("cover.test", 50)
     past_state.last_updated = dt.datetime.now(dt.UTC) - dt.timedelta(seconds=1)
     event = state_data_class("cover.test", None, past_state)
-    manager.handle_state_change(event, 10, "cover", True, {}, None)
+    manager.handle_state_change(event, 10, SensorType.BLIND, True, {}, None)
     assert manager.is_cover_manual("cover.test")
     import asyncio
 


### PR DESCRIPTION
## Summary
- replace static SensorType class with a `StrEnum`
- reference the enum throughout config flow and coordinator
- update cover manager and tests for new enum usage

## Testing
- `scripts/test`

------
https://chatgpt.com/codex/tasks/task_e_68582de1cbdc832e96467bff2f7ac8af