### PR TITLE
Add docstrings for tests

### DIFF
--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -1,3 +1,5 @@
+"""Tests for the config flow helpers."""
+
 import importlib
 import sys
 from pathlib import Path
@@ -16,6 +18,8 @@ except Exception as exc:
 
 @pytest.mark.asyncio
 async def test_vertical_schema_callable():
+    """Ensure the vertical step returns a callable schema."""
+
     handler = cf.ConfigFlowHandler()
     result = await handler.async_step_vertical(None)
     schema = result["data_schema"]

--- a/tests/test_cover_manager.py
+++ b/tests/test_cover_manager.py
@@ -10,6 +10,8 @@ import pytest
 
 @pytest.fixture
 def manager_module():
+    """Import and return the cover_manager module under test."""
+
     from tests.conftest import import_module
 
     return import_module(
@@ -20,15 +22,21 @@ def manager_module():
 
 @pytest.fixture
 def state_data_class(coordinator):
+    """Return the data class used for state change events."""
+
     return coordinator.StateChangedData
 
 
 def make_manager(manager_module, seconds=30):
+    """Create an AdaptiveCoverManager instance for testing."""
+
     logger = types.SimpleNamespace(debug=lambda *a, **k: None)
     return manager_module.AdaptiveCoverManager({"seconds": seconds}, logger)
 
 
 def make_state(entity_id: str, position: int, cover_type="cover"):
+    """Return a `State` object with the desired position."""
+
     from homeassistant.core import State
 
     attr = {
@@ -40,6 +48,7 @@ def make_state(entity_id: str, position: int, cover_type="cover"):
 
 
 def test_add_and_basic_properties(manager_module):
+    """Verify that covers are added and tracked correctly."""
     manager = make_manager(manager_module)
     manager.add_covers({"cover.one", "cover.two"})
     assert manager.covers == {"cover.one", "cover.two"}
@@ -50,6 +59,7 @@ def test_add_and_basic_properties(manager_module):
 
 
 def test_handle_state_change_marks_manual(manager_module, state_data_class):
+    """Ensure state changes mark covers as manual when appropriate."""
     manager = make_manager(manager_module)
     manager.add_covers({"cover.test"})
     our_state = 10
@@ -60,6 +70,7 @@ def test_handle_state_change_marks_manual(manager_module, state_data_class):
 
 
 def test_handle_state_change_threshold(manager_module, state_data_class):
+    """Check manual control is not set when below threshold."""
     manager = make_manager(manager_module)
     manager.add_covers({"cover.test"})
     our_state = 10
@@ -69,6 +80,7 @@ def test_handle_state_change_threshold(manager_module, state_data_class):
 
 
 def test_reset_if_needed(manager_module, state_data_class):
+    """Validate that manual control flags reset after the cooldown."""
     manager = make_manager(manager_module, seconds=0)
     manager.add_covers({"cover.test"})
     past_state = make_state("cover.test", 50)


### PR DESCRIPTION
## Summary
- add missing module and function docstrings in `tests/test_config_flow.py`
- add docstrings for fixtures, helpers, and tests in `tests/test_cover_manager.py`

## Testing
- `./scripts/lint`
- `./scripts/test`

------
https://chatgpt.com/codex/tasks/task_e_68582e688cbc832e989b0897e4becdf8