### PR TITLE
Refactor blind step handling

### DIFF
--- a/custom_components/simple_auto_cover/config_flow.py
+++ b/custom_components/simple_auto_cover/config_flow.py
@@ -277,6 +277,42 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
         """Get the options flow for this handler."""
         return OptionsFlowHandler(config_entry)
 
+    async def _handle_blind_step(
+        self,
+        user_input: dict[str, Any] | None,
+        schema: vol.Schema,
+        sensor_type: SensorType,
+        step_id: str,
+    ) -> FlowResult:
+        """Process shared validation and branching logic for blind steps."""
+        self.type_blind = sensor_type
+
+        if user_input is not None:
+            if (
+                user_input.get(CONF_MAX_ELEVATION) is not None
+                and user_input.get(CONF_MIN_ELEVATION) is not None
+                and user_input[CONF_MAX_ELEVATION]
+                <= user_input[CONF_MIN_ELEVATION]
+            ):
+                return self.async_show_form(
+                    step_id=step_id,
+                    data_schema=schema,
+                    errors={
+                        CONF_MAX_ELEVATION: "Must be greater than 'Minimal Elevation'"
+                    },
+                )
+
+            self.config.update(user_input)
+
+            if self.config[CONF_INTERP]:
+                return await self.async_step_interp()
+            if self.config[CONF_ENABLE_BLIND_SPOT]:
+                return await self.async_step_blind_spot()
+
+            return await self.async_step_automation()
+
+        return self.async_show_form(step_id=step_id, data_schema=schema)
+
     async def async_step_user(self, user_input: dict[str, Any] | None = None):
         """Handle the initial step."""
         # errors = {}
@@ -292,81 +328,30 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
 
     async def async_step_vertical(self, user_input: dict[str, Any] | None = None):
         """Show basic config for vertical blinds."""
-        self.type_blind = SensorType.BLIND
-        if user_input is not None:
-            if (
-                user_input.get(CONF_MAX_ELEVATION) is not None
-                and user_input.get(CONF_MIN_ELEVATION) is not None
-            ):
-                if user_input[CONF_MAX_ELEVATION] <= user_input[CONF_MIN_ELEVATION]:
-                    return self.async_show_form(
-                        step_id="vertical",
-                        data_schema=VERTICAL_OPTIONS,
-                        errors={
-                            CONF_MAX_ELEVATION: "Must be greater than 'Minimal Elevation'"
-                        },
-                    )
-            self.config.update(user_input)
-            if self.config[CONF_INTERP]:
-                return await self.async_step_interp()
-            if self.config[CONF_ENABLE_BLIND_SPOT]:
-                return await self.async_step_blind_spot()
-            return await self.async_step_automation()
-        return self.async_show_form(
-            step_id="vertical",
-            data_schema=VERTICAL_OPTIONS,
+        return await self._handle_blind_step(
+            user_input,
+            VERTICAL_OPTIONS,
+            SensorType.BLIND,
+            "vertical",
         )
 
     async def async_step_horizontal(self, user_input: dict[str, Any] | None = None):
         """Show basic config for horizontal blinds."""
-        self.type_blind = SensorType.AWNING
-        if user_input is not None:
-            if (
-                user_input.get(CONF_MAX_ELEVATION) is not None
-                and user_input.get(CONF_MIN_ELEVATION) is not None
-            ):
-                if user_input[CONF_MAX_ELEVATION] <= user_input[CONF_MIN_ELEVATION]:
-                    return self.async_show_form(
-                        step_id="horizontal",
-                        data_schema=HORIZONTAL_OPTIONS,
-                        errors={
-                            CONF_MAX_ELEVATION: "Must be greater than 'Minimal Elevation'"
-                        },
-                    )
-            self.config.update(user_input)
-            if self.config[CONF_INTERP]:
-                return await self.async_step_interp()
-            if self.config[CONF_ENABLE_BLIND_SPOT]:
-                return await self.async_step_blind_spot()
-            return await self.async_step_automation()
-        return self.async_show_form(
-            step_id="horizontal",
-            data_schema=HORIZONTAL_OPTIONS,
+        return await self._handle_blind_step(
+            user_input,
+            HORIZONTAL_OPTIONS,
+            SensorType.AWNING,
+            "horizontal",
         )
 
     async def async_step_tilt(self, user_input: dict[str, Any] | None = None):
         """Show basic config for tilted blinds."""
-        self.type_blind = SensorType.TILT
-        if user_input is not None:
-            if (
-                user_input.get(CONF_MAX_ELEVATION) is not None
-                and user_input.get(CONF_MIN_ELEVATION) is not None
-            ):
-                if user_input[CONF_MAX_ELEVATION] <= user_input[CONF_MIN_ELEVATION]:
-                    return self.async_show_form(
-                        step_id="tilt",
-                        data_schema=TILT_OPTIONS,
-                        errors={
-                            CONF_MAX_ELEVATION: "Must be greater than 'Minimal Elevation'"
-                        },
-                    )
-            self.config.update(user_input)
-            if self.config[CONF_INTERP]:
-                return await self.async_step_interp()
-            if self.config[CONF_ENABLE_BLIND_SPOT]:
-                return await self.async_step_blind_spot()
-            return await self.async_step_automation()
-        return self.async_show_form(step_id="tilt", data_schema=TILT_OPTIONS)
+        return await self._handle_blind_step(
+            user_input,
+            TILT_OPTIONS,
+            SensorType.TILT,
+            "tilt",
+        )
 
     async def async_step_interp(self, user_input: dict[str, Any] | None = None):
         """Show interpolation options."""

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -21,3 +21,77 @@ async def test_vertical_schema_callable():
     schema = result["data_schema"]
     assert callable(schema)
     assert isinstance(schema({}), dict)
+
+
+@pytest.mark.asyncio
+async def test_blind_step_sets_type():
+    """Ensure each blind step assigns the correct sensor type."""
+    handler = cf.ConfigFlowHandler()
+
+    await handler.async_step_vertical(None)
+    assert handler.type_blind == cf.SensorType.BLIND
+
+    handler = cf.ConfigFlowHandler()
+    await handler.async_step_horizontal(None)
+    assert handler.type_blind == cf.SensorType.AWNING
+
+    handler = cf.ConfigFlowHandler()
+    await handler.async_step_tilt(None)
+    assert handler.type_blind == cf.SensorType.TILT
+
+
+class DummyFlow(cf.ConfigFlowHandler):
+    """Expose next step calls for testing."""
+
+    def __init__(self):
+        super().__init__()
+        self.called: list[str] = []
+
+    async def async_step_interp(self):
+        self.called.append("interp")
+        return self.async_show_form(step_id="interp", data_schema=cf.INTERPOLATION_OPTIONS)
+
+    async def async_step_blind_spot(self):
+        self.called.append("blind_spot")
+        return self.async_show_form(step_id="blind_spot", data_schema=cf.AUTOMATION_CONFIG)
+
+    async def async_step_automation(self):
+        self.called.append("automation")
+        return self.async_show_form(step_id="automation", data_schema=cf.AUTOMATION_CONFIG)
+
+
+@pytest.mark.asyncio
+async def test_blind_step_branches():
+    """Validate branching logic of the blind setup helper."""
+    handler = DummyFlow()
+    data = {cf.CONF_INTERP: True, cf.CONF_ENABLE_BLIND_SPOT: False}
+    result = await handler.async_step_vertical(data)
+    assert handler.called == ["interp"]
+    assert result["step_id"] == "interp"
+
+    handler = DummyFlow()
+    data = {cf.CONF_INTERP: False, cf.CONF_ENABLE_BLIND_SPOT: True}
+    result = await handler.async_step_vertical(data)
+    assert handler.called == ["blind_spot"]
+    assert result["step_id"] == "blind_spot"
+
+    handler = DummyFlow()
+    data = {cf.CONF_INTERP: False, cf.CONF_ENABLE_BLIND_SPOT: False}
+    result = await handler.async_step_vertical(data)
+    assert handler.called == ["automation"]
+    assert result["step_id"] == "automation"
+
+
+@pytest.mark.asyncio
+async def test_blind_step_validation():
+    """Check validation of min/max elevation in the helper."""
+    handler = cf.ConfigFlowHandler()
+    data = {
+        cf.CONF_MIN_ELEVATION: 10,
+        cf.CONF_MAX_ELEVATION: 5,
+        cf.CONF_INTERP: False,
+        cf.CONF_ENABLE_BLIND_SPOT: False,
+    }
+    result = await handler.async_step_vertical(data)
+    assert result["type"] == "form"
+    assert result["errors"] == {cf.CONF_MAX_ELEVATION: "Must be greater than 'Minimal Elevation'"}


### PR DESCRIPTION
## Summary
- simplify config flow by consolidating repeated blind step logic in `_handle_blind_step`
- use helper in vertical, horizontal and tilt setup paths
- add tests for `_handle_blind_step` to verify branching and validation

## Testing
- `scripts/test`


------
https://chatgpt.com/codex/tasks/task_e_68582dcb1634832e909d85d6b0103ec4