### PR TITLE
Introduce AdaptiveCoverEntity base class

### DIFF
--- a/custom_components/simple_auto_cover/binary_sensor.py
+++ b/custom_components/simple_auto_cover/binary_sensor.py
@@ -11,12 +11,11 @@ from homeassistant.components.binary_sensor import (
 )
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.device_registry import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import CONF_SENSOR_TYPE, DOMAIN, COVER_TYPE_DISPLAY
+from .const import DOMAIN
 from .coordinator import AdaptiveDataUpdateCoordinator
+from .entity import AdaptiveCoverEntity
 
 
 async def async_setup_entry(
@@ -50,9 +49,7 @@ async def async_setup_entry(
     async_add_entities([binary_sensor, manual_override])
 
 
-class AdaptiveCoverBinarySensor(
-    CoordinatorEntity[AdaptiveDataUpdateCoordinator], BinarySensorEntity
-):
+class AdaptiveCoverBinarySensor(AdaptiveCoverEntity, BinarySensorEntity):
     """Representation of a simple auto cover binary sensor."""
 
     _attr_has_entity_name = True
@@ -69,21 +66,13 @@ class AdaptiveCoverBinarySensor(
         coordinator: AdaptiveDataUpdateCoordinator,
     ) -> None:
         """Initialize the binary sensor."""
-        super().__init__(coordinator=coordinator)
-        self.type = COVER_TYPE_DISPLAY
+        super().__init__(config_entry, unique_id, coordinator)
         self._key = key
         self._attr_translation_key = key
-        self._name = config_entry.data["name"]
-        self._device_name = self.type[config_entry.data[CONF_SENSOR_TYPE]]
         self._binary_name = binary_name
         self._attr_unique_id = f"{unique_id}_{binary_name}"
-        self._device_id = unique_id
         self._state = state
         self._attr_device_class = device_class
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, self._device_id)},
-            name=self._device_name,
-        )
 
     @property
     def name(self):

--- a/custom_components/simple_auto_cover/button.py
+++ b/custom_components/simple_auto_cover/button.py
@@ -7,18 +7,15 @@ import asyncio
 from homeassistant.components.button import ButtonEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import (
     _LOGGER,
     CONF_ENTITIES,
-    CONF_SENSOR_TYPE,
     DOMAIN,
-    COVER_TYPE_DISPLAY,
 )
 from .coordinator import AdaptiveDataUpdateCoordinator
+from .entity import AdaptiveCoverEntity
 
 
 async def async_setup_entry(
@@ -44,9 +41,7 @@ async def async_setup_entry(
     async_add_entities(buttons)
 
 
-class AdaptiveCoverButton(
-    CoordinatorEntity[AdaptiveDataUpdateCoordinator], ButtonEntity
-):
+class AdaptiveCoverButton(AdaptiveCoverEntity, ButtonEntity):
     """Representation of a simple auto cover button."""
 
     _attr_has_entity_name = True
@@ -61,18 +56,10 @@ class AdaptiveCoverButton(
         coordinator: AdaptiveDataUpdateCoordinator,
     ) -> None:
         """Initialize the button."""
-        super().__init__(coordinator=coordinator)
-        self.type = COVER_TYPE_DISPLAY
-        self._name = config_entry.data["name"]
-        self._device_name = self.type[config_entry.data[CONF_SENSOR_TYPE]]
+        super().__init__(config_entry, unique_id, coordinator)
         self._attr_unique_id = f"{unique_id}_{button_name}"
-        self._device_id = unique_id
         self._button_name = button_name
         self._entities = config_entry.options.get(CONF_ENTITIES, [])
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, self._device_id)},
-            name=self._device_name,
-        )
 
     @property
     def name(self):

--- a/custom_components/simple_auto_cover/entity.py
+++ b/custom_components/simple_auto_cover/entity.py
@@ -1,0 +1,32 @@
+"""Base entity for the Simple Auto Cover integration."""
+
+from __future__ import annotations
+
+from homeassistant.helpers.entity import DeviceInfo
+from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .const import CONF_SENSOR_TYPE, COVER_TYPE_DISPLAY, DOMAIN
+from .coordinator import AdaptiveDataUpdateCoordinator
+
+
+class AdaptiveCoverEntity(CoordinatorEntity[AdaptiveDataUpdateCoordinator]):
+    """Common entity base class for Simple Auto Cover."""
+
+    def __init__(
+        self,
+        config_entry,
+        unique_id: str,
+        coordinator: AdaptiveDataUpdateCoordinator,
+    ) -> None:
+        """Initialize the entity."""
+        super().__init__(coordinator=coordinator)
+        self.type = COVER_TYPE_DISPLAY
+        self.config_entry = config_entry
+        self._name = config_entry.data["name"]
+        self._device_id = unique_id
+        self._device_name = self.type[config_entry.data[CONF_SENSOR_TYPE]]
+        self._attr_device_info = DeviceInfo(
+            identifiers={(DOMAIN, self._device_id)},
+            name=self._device_name,
+        )
+

--- a/custom_components/simple_auto_cover/sensor.py
+++ b/custom_components/simple_auto_cover/sensor.py
@@ -16,14 +16,10 @@ from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
-from .const import (
-    CONF_SENSOR_TYPE,
-    DOMAIN,
-    COVER_TYPE_DISPLAY,
-)
+from .const import DOMAIN
 from .coordinator import AdaptiveDataUpdateCoordinator
+from .entity import AdaptiveCoverEntity
 
 
 async def async_setup_entry(
@@ -67,9 +63,7 @@ async def async_setup_entry(
     async_add_entities([sensor, start, end, control])
 
 
-class AdaptiveCoverSensorEntity(
-    CoordinatorEntity[AdaptiveDataUpdateCoordinator], SensorEntity
-):
+class AdaptiveCoverSensorEntity(AdaptiveCoverEntity, SensorEntity):
     """Simple Auto Cover Sensor."""
 
     _attr_state_class = SensorStateClass.MEASUREMENT
@@ -87,8 +81,7 @@ class AdaptiveCoverSensorEntity(
         coordinator: AdaptiveDataUpdateCoordinator,
     ) -> None:
         """Initialize simple_auto_cover Sensor."""
-        super().__init__(coordinator=coordinator)
-        self.type = COVER_TYPE_DISPLAY
+        super().__init__(config_entry, unique_id, coordinator)
         self.coordinator = coordinator
         self.data = self.coordinator.data
         self._sensor_name = "Cover Position"
@@ -96,8 +89,11 @@ class AdaptiveCoverSensorEntity(
         self.hass = hass
         self.config_entry = config_entry
         self._name = name
-        self._device_name = self.type[self.config_entry.data[CONF_SENSOR_TYPE]]
-        self._device_id = unique_id
+        self._attr_device_info = DeviceInfo(
+            entry_type=DeviceEntryType.SERVICE,
+            identifiers={(DOMAIN, self._device_id)},
+            name=self._device_name,
+        )
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -116,22 +112,11 @@ class AdaptiveCoverSensorEntity(
         return self.data.states["state"]
 
     @property
-    def device_info(self) -> DeviceInfo:
-        """Return device info."""
-        return DeviceInfo(
-            entry_type=DeviceEntryType.SERVICE,
-            identifiers={(DOMAIN, self._device_id)},
-            name=self._device_name,
-        )
-
-    @property
     def extra_state_attributes(self) -> Mapping[str, Any] | None:  # noqa: D102
         return self.data.attributes
 
 
-class AdaptiveCoverTimeSensorEntity(
-    CoordinatorEntity[AdaptiveDataUpdateCoordinator], SensorEntity
-):
+class AdaptiveCoverTimeSensorEntity(AdaptiveCoverEntity, SensorEntity):
     """Simple Auto Cover Time Sensor."""
 
     _attr_device_class = SensorDeviceClass.TIMESTAMP
@@ -150,8 +135,7 @@ class AdaptiveCoverTimeSensorEntity(
         coordinator: AdaptiveDataUpdateCoordinator,
     ) -> None:
         """Initialize simple_auto_cover Sensor."""
-        super().__init__(coordinator=coordinator)
-        self.type = COVER_TYPE_DISPLAY
+        super().__init__(config_entry, unique_id, coordinator)
         self._attr_icon = icon
         self.key = key
         self.coordinator = coordinator
@@ -163,7 +147,11 @@ class AdaptiveCoverTimeSensorEntity(
         self._name = name
         self._cover_type = self.config_entry.data["sensor_type"]
         self._sensor_name = sensor_name
-        self._device_name = self.type[config_entry.data[CONF_SENSOR_TYPE]]
+        self._attr_device_info = DeviceInfo(
+            entry_type=DeviceEntryType.SERVICE,
+            identifiers={(DOMAIN, self._device_id)},
+            name=self._device_name,
+        )
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -181,19 +169,9 @@ class AdaptiveCoverTimeSensorEntity(
         """Handle when entity is added."""
         return self.data.states[self.key]
 
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return device info."""
-        return DeviceInfo(
-            entry_type=DeviceEntryType.SERVICE,
-            identifiers={(DOMAIN, self._device_id)},
-            name=self._device_name,
-        )
 
 
-class AdaptiveCoverControlSensorEntity(
-    CoordinatorEntity[AdaptiveDataUpdateCoordinator], SensorEntity
-):
+class AdaptiveCoverControlSensorEntity(AdaptiveCoverEntity, SensorEntity):
     """Simple Auto Cover Control method Sensor."""
 
     _attr_has_entity_name = True
@@ -209,8 +187,7 @@ class AdaptiveCoverControlSensorEntity(
         coordinator: AdaptiveDataUpdateCoordinator,
     ) -> None:
         """Initialize simple_auto_cover Sensor."""
-        super().__init__(coordinator=coordinator)
-        self.type = COVER_TYPE_DISPLAY
+        super().__init__(config_entry, unique_id, coordinator)
         self.coordinator = coordinator
         self.data = self.coordinator.data
         self._sensor_name = "Control Method"
@@ -221,7 +198,11 @@ class AdaptiveCoverControlSensorEntity(
         self.config_entry = config_entry
         self._name = name
         self._cover_type = self.config_entry.data["sensor_type"]
-        self._device_name = self.type[config_entry.data[CONF_SENSOR_TYPE]]
+        self._attr_device_info = DeviceInfo(
+            entry_type=DeviceEntryType.SERVICE,
+            identifiers={(DOMAIN, self._device_id)},
+            name=self._device_name,
+        )
 
     @callback
     def _handle_coordinator_update(self) -> None:
@@ -239,11 +220,3 @@ class AdaptiveCoverControlSensorEntity(
         """Handle when entity is added."""
         return self.data.states["control"]
 
-    @property
-    def device_info(self) -> DeviceInfo:
-        """Return device info."""
-        return DeviceInfo(
-            entry_type=DeviceEntryType.SERVICE,
-            identifiers={(DOMAIN, self._device_id)},
-            name=self._device_name,
-        )

--- a/custom_components/simple_auto_cover/switch.py
+++ b/custom_components/simple_auto_cover/switch.py
@@ -8,18 +8,15 @@ from homeassistant.components.switch import SwitchDeviceClass, SwitchEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import STATE_ON
 from homeassistant.core import HomeAssistant
-from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 from homeassistant.helpers.restore_state import RestoreEntity
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import (
     CONF_ENTITIES,
-    CONF_SENSOR_TYPE,
     DOMAIN,
-    COVER_TYPE_DISPLAY,
 )
 from .coordinator import AdaptiveDataUpdateCoordinator
+from .entity import AdaptiveCoverEntity
 
 
 async def async_setup_entry(
@@ -56,9 +53,7 @@ async def async_setup_entry(
     async_add_entities(switches)
 
 
-class AdaptiveCoverSwitch(
-    CoordinatorEntity[AdaptiveDataUpdateCoordinator], SwitchEntity, RestoreEntity
-):
+class AdaptiveCoverSwitch(AdaptiveCoverEntity, SwitchEntity, RestoreEntity):
     """Representation of a simple auto cover switch."""
 
     _attr_has_entity_name = True
@@ -75,22 +70,14 @@ class AdaptiveCoverSwitch(
         device_class: SwitchDeviceClass | None = None,
     ) -> None:
         """Initialize the switch."""
-        super().__init__(coordinator=coordinator)
-        self.type = COVER_TYPE_DISPLAY
-        self._name = config_entry.data["name"]
+        super().__init__(config_entry, unique_id, coordinator)
         self._state: bool | None = None
         self._key = key
         self._attr_translation_key = key
-        self._device_name = self.type[config_entry.data[CONF_SENSOR_TYPE]]
         self._switch_name = switch_name
         self._attr_device_class = device_class
         self._initial_state = initial_state
         self._attr_unique_id = f"{unique_id}_{switch_name}"
-        self._device_id = unique_id
-        self._attr_device_info = DeviceInfo(
-            identifiers={(DOMAIN, self._device_id)},
-            name=self._device_name,
-        )
 
         self.coordinator.logger.debug("Setup switch")
 

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1,0 +1,146 @@
+import types
+import pytest
+
+from tests.conftest import import_module
+from custom_components.simple_auto_cover import const
+
+
+@pytest.fixture
+def entity_module():
+    return import_module(
+        "custom_components/simple_auto_cover/entity.py",
+        "custom_components.simple_auto_cover.entity",
+    )
+
+
+@pytest.fixture
+def button_module():
+    return import_module(
+        "custom_components/simple_auto_cover/button.py",
+        "custom_components.simple_auto_cover.button",
+    )
+
+
+@pytest.fixture
+def binary_sensor_module():
+    return import_module(
+        "custom_components/simple_auto_cover/binary_sensor.py",
+        "custom_components.simple_auto_cover.binary_sensor",
+    )
+
+
+@pytest.fixture
+def sensor_module():
+    return import_module(
+        "custom_components/simple_auto_cover/sensor.py",
+        "custom_components.simple_auto_cover.sensor",
+    )
+
+
+@pytest.fixture
+def switch_module():
+    return import_module(
+        "custom_components/simple_auto_cover/switch.py",
+        "custom_components.simple_auto_cover.switch",
+    )
+
+
+class DummyCoordinator:
+    """Simplified coordinator for entity tests."""
+
+    def __init__(self, states=None, attrs=None):
+        self.data = types.SimpleNamespace(states=states or {}, attributes=attrs or {})
+        self.last_update_success = True
+        self.logger = types.SimpleNamespace(debug=lambda *a, **k: None)
+
+    async def async_request_refresh(self):
+        pass
+
+    async def async_refresh(self):
+        pass
+
+    def async_add_listener(self, *_):
+        return lambda: None
+
+
+def make_entry(*, name="Test", sensor_type=None):
+    return types.SimpleNamespace(
+        data={"name": name, const.CONF_SENSOR_TYPE: sensor_type or const.SensorType.BLIND},
+        options={const.CONF_ENTITIES: ["cover.one"]},
+        entry_id="1",
+    )
+
+def test_base_entity_initialization(entity_module):
+    entry = make_entry()
+    coord = DummyCoordinator()
+    entity = entity_module.AdaptiveCoverEntity(entry, "uid", coord)
+
+    assert entity._device_id == "uid"
+    assert entity._name == entry.data["name"]
+    assert entity._device_name == const.COVER_TYPE_DISPLAY[entry.data[const.CONF_SENSOR_TYPE]]
+    assert entity.device_info["identifiers"] == {(const.DOMAIN, "uid")}
+
+
+def test_button_inherits_base(entity_module, button_module):
+    entry = make_entry()
+    coord = DummyCoordinator()
+    button = button_module.AdaptiveCoverButton(entry, "uid", "Reset", coord)
+
+    assert isinstance(button, entity_module.AdaptiveCoverEntity)
+    assert button.name == "Reset " + entry.data["name"]
+    assert button.device_info["name"] == const.COVER_TYPE_DISPLAY[entry.data[const.CONF_SENSOR_TYPE]]
+    assert button.unique_id == "uid_Reset"
+
+
+def test_binary_sensor_is_on(entity_module, binary_sensor_module):
+    entry = make_entry()
+    coord = DummyCoordinator(states={"sun": True, "manual_list": []})
+    sensor = binary_sensor_module.AdaptiveCoverBinarySensor(
+        entry,
+        "uid",
+        "Sun",
+        False,
+        "sun",
+        binary_sensor_module.BinarySensorDeviceClass.MOTION,
+        coord,
+    )
+
+    assert isinstance(sensor, entity_module.AdaptiveCoverEntity)
+    assert sensor.is_on is True
+    assert sensor.name == "Sun " + entry.data["name"]
+    assert sensor.unique_id == "uid_Sun"
+
+
+def test_sensor_native_value(entity_module, sensor_module):
+    entry = make_entry()
+    states = {"state": 55, "start": "2025-01-01", "end": "2025-01-02", "control": "auto"}
+    coord = DummyCoordinator(states=states, attrs={"foo": "bar"})
+
+    sensor = sensor_module.AdaptiveCoverSensorEntity("uid", None, entry, entry.data["name"], coord)
+    assert sensor.native_value == 55
+    assert sensor.extra_state_attributes == {"foo": "bar"}
+
+    time_sensor = sensor_module.AdaptiveCoverTimeSensorEntity(
+        "uid",
+        None,
+        entry,
+        entry.data["name"],
+        "Start Sun",
+        "start",
+        "icon",
+        coord,
+    )
+    assert time_sensor.native_value == states["start"]
+
+    control_sensor = sensor_module.AdaptiveCoverControlSensorEntity("uid", None, entry, entry.data["name"], coord)
+    assert control_sensor.native_value == "auto"
+
+
+def test_switch_initial_state(entity_module, switch_module):
+    entry = make_entry()
+    coord = DummyCoordinator()
+    switch = switch_module.AdaptiveCoverSwitch(entry, "uid", "Manual", True, "manual_toggle", coord)
+
+    assert isinstance(switch, entity_module.AdaptiveCoverEntity)
+    assert switch.name == "Manual " + entry.data["name"]
+    assert switch.unique_id == "uid_Manual"


### PR DESCRIPTION
## Summary
- add new `entity.py` module for common entity logic
- refactor button, binary sensor, sensor and switch modules to inherit from `AdaptiveCoverEntity`
- include tests for shared entity behavior across platforms

## Testing
- `scripts/test`


------
https://chatgpt.com/codex/tasks/task_e_68582dd6229c832ea42fa5925e82d3da