### PR TITLE
Add AGENTS instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,19 @@
+# Agent Guidelines
+
+This file defines conventions for automated tools contributing to this repository.
+
+## Development workflow
+
+- **Formatting and linting**: run `scripts/lint` to automatically format the
+  codebase using `ruff`.
+- **Testing**: run `scripts/test` to execute the pytest suite.
+- Add or update tests when modifying functionality or fixing bugs.
+- Include helpful comments for any complicated logic.
+- Provide docstrings for all functions and classes.
+- If these scripts fail because dependencies are missing or the environment lacks
+  internet access, note it in the PR testing section.
+
+## Pull request message
+
+Include a brief summary of changes and testing results. Mention any linting or
+tests that could not be run.


### PR DESCRIPTION
## Summary
- add AGENTS guidelines for automated contributors
- expand guidance for comments, docstrings, and tests

## Testing
- `./scripts/lint` *(fails: D100 & D103 errors)*
- `./scripts/test`


------
https://chatgpt.com/codex/tasks/task_e_685830f9f698832ebe12942aae2566be