### PR TITLE
Fix lint errors

### DIFF
--- a/custom_components/simple_auto_cover/const.py
+++ b/custom_components/simple_auto_cover/const.py
@@ -1,5 +1,6 @@
 """Constants for integration_blueprint."""
 
+from enum import StrEnum
 import logging
 
 DOMAIN = "simple_auto_cover"
@@ -60,9 +61,6 @@ FORCE_MODE = "force_mode"
 
 STRATEGY_MODE_BASIC = "basic"
 STRATEGY_MODES = [STRATEGY_MODE_BASIC]
-
-
-from enum import StrEnum
 
 
 class SensorType(StrEnum):

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -48,18 +48,22 @@ class DummyFlow(cf.ConfigFlowHandler):
     """Expose next step calls for testing."""
 
     def __init__(self):
+        """Initialize with a record of called steps."""
         super().__init__()
         self.called: list[str] = []
 
     async def async_step_interp(self):
+        """Handle the interpolation step."""
         self.called.append("interp")
         return self.async_show_form(step_id="interp", data_schema=cf.INTERPOLATION_OPTIONS)
 
     async def async_step_blind_spot(self):
+        """Handle the blind spot step."""
         self.called.append("blind_spot")
         return self.async_show_form(step_id="blind_spot", data_schema=cf.AUTOMATION_CONFIG)
 
     async def async_step_automation(self):
+        """Handle the automation step."""
         self.called.append("automation")
         return self.async_show_form(step_id="automation", data_schema=cf.AUTOMATION_CONFIG)
 

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -1,3 +1,5 @@
+"""Unit tests for the entity helpers."""
+
 import types
 import pytest
 
@@ -7,6 +9,7 @@ from custom_components.simple_auto_cover import const
 
 @pytest.fixture
 def entity_module():
+    """Return the base entity module."""
     return import_module(
         "custom_components/simple_auto_cover/entity.py",
         "custom_components.simple_auto_cover.entity",
@@ -15,6 +18,7 @@ def entity_module():
 
 @pytest.fixture
 def button_module():
+    """Return the button module."""
     return import_module(
         "custom_components/simple_auto_cover/button.py",
         "custom_components.simple_auto_cover.button",
@@ -23,6 +27,7 @@ def button_module():
 
 @pytest.fixture
 def binary_sensor_module():
+    """Return the binary sensor module."""
     return import_module(
         "custom_components/simple_auto_cover/binary_sensor.py",
         "custom_components.simple_auto_cover.binary_sensor",
@@ -31,6 +36,7 @@ def binary_sensor_module():
 
 @pytest.fixture
 def sensor_module():
+    """Return the sensor module."""
     return import_module(
         "custom_components/simple_auto_cover/sensor.py",
         "custom_components.simple_auto_cover.sensor",
@@ -39,6 +45,7 @@ def sensor_module():
 
 @pytest.fixture
 def switch_module():
+    """Return the switch module."""
     return import_module(
         "custom_components/simple_auto_cover/switch.py",
         "custom_components.simple_auto_cover.switch",
@@ -49,21 +56,26 @@ class DummyCoordinator:
     """Simplified coordinator for entity tests."""
 
     def __init__(self, states=None, attrs=None):
+        """Initialize with optional state and attribute dictionaries."""
         self.data = types.SimpleNamespace(states=states or {}, attributes=attrs or {})
         self.last_update_success = True
         self.logger = types.SimpleNamespace(debug=lambda *a, **k: None)
 
     async def async_request_refresh(self):
+        """Mock request of a data refresh."""
         pass
 
     async def async_refresh(self):
+        """Mock refresh callback."""
         pass
 
     def async_add_listener(self, *_):
+        """Return a dummy remove callback for listeners."""
         return lambda: None
 
 
 def make_entry(*, name="Test", sensor_type=None):
+    """Create a simple config entry namespace for tests."""
     return types.SimpleNamespace(
         data={"name": name, const.CONF_SENSOR_TYPE: sensor_type or const.SensorType.BLIND},
         options={const.CONF_ENTITIES: ["cover.one"]},
@@ -71,6 +83,7 @@ def make_entry(*, name="Test", sensor_type=None):
     )
 
 def test_base_entity_initialization(entity_module):
+    """Ensure base entity is initialized with the correct attributes."""
     entry = make_entry()
     coord = DummyCoordinator()
     entity = entity_module.AdaptiveCoverEntity(entry, "uid", coord)
@@ -82,6 +95,7 @@ def test_base_entity_initialization(entity_module):
 
 
 def test_button_inherits_base(entity_module, button_module):
+    """Verify button inherits from the base entity class."""
     entry = make_entry()
     coord = DummyCoordinator()
     button = button_module.AdaptiveCoverButton(entry, "uid", "Reset", coord)
@@ -93,6 +107,7 @@ def test_button_inherits_base(entity_module, button_module):
 
 
 def test_binary_sensor_is_on(entity_module, binary_sensor_module):
+    """Confirm binary sensor reports its state correctly."""
     entry = make_entry()
     coord = DummyCoordinator(states={"sun": True, "manual_list": []})
     sensor = binary_sensor_module.AdaptiveCoverBinarySensor(
@@ -112,6 +127,7 @@ def test_binary_sensor_is_on(entity_module, binary_sensor_module):
 
 
 def test_sensor_native_value(entity_module, sensor_module):
+    """Validate sensor entities expose the expected values."""
     entry = make_entry()
     states = {"state": 55, "start": "2025-01-01", "end": "2025-01-02", "control": "auto"}
     coord = DummyCoordinator(states=states, attrs={"foo": "bar"})
@@ -137,6 +153,7 @@ def test_sensor_native_value(entity_module, sensor_module):
 
 
 def test_switch_initial_state(entity_module, switch_module):
+    """Check initial attributes of the manual override switch."""
     entry = make_entry()
     coord = DummyCoordinator()
     switch = switch_module.AdaptiveCoverSwitch(entry, "uid", "Manual", True, "manual_toggle", coord)


### PR DESCRIPTION
## Summary
- move enum import in consts
- add docstrings to DummyFlow
- document test utilities and fixtures

## Testing
- `scripts/lint`
- `scripts/test`

------
https://chatgpt.com/codex/tasks/task_e_68583438d9dc832e8b1971d9a2ad997d