### PR TITLE
Fix interpolation range check

### DIFF
--- a/custom_components/simple_auto_cover/coordinator.py
+++ b/custom_components/simple_auto_cover/coordinator.py
@@ -692,8 +692,11 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         """Interpolate states."""
         normal_range = [0, 100]
         new_range = []
-        if self.start_value and self.end_value:
-            new_range = [self.start_value, self.end_value]
+        # Allow partial range overrides by falling back to defaults
+        if self.start_value is not None or self.end_value is not None:
+            start = self.start_value if self.start_value is not None else 0
+            end = self.end_value if self.end_value is not None else 100
+            new_range = [start, end]
         if self.normal_list and self.new_list:
             normal_range = list(map(int, self.normal_list))
             new_range = list(map(int, self.new_list))

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -124,3 +124,43 @@ def test_async_timed_refresh_without_end_time(module):
 
     asyncio.run(coord.async_timed_refresh(None))
     assert coord.timed_refresh is False
+
+
+def test_interpolate_states_default(module):
+    """Ensure no adjustment occurs with no custom range."""
+    coord, _ = make_coordinator(module)
+    coord.start_value = None
+    coord.end_value = None
+    coord.normal_list = []
+    coord.new_list = []
+    assert coord.interpolate_states(50) == 50
+
+
+def test_interpolate_states_start_only(module):
+    """Interpolate when only the starting value is provided."""
+    coord, _ = make_coordinator(module)
+    coord.start_value = 20
+    coord.end_value = None
+    coord.normal_list = []
+    coord.new_list = []
+    assert coord.interpolate_states(50) == 60
+
+
+def test_interpolate_states_end_only(module):
+    """Interpolate when only the ending value is provided."""
+    coord, _ = make_coordinator(module)
+    coord.start_value = None
+    coord.end_value = 80
+    coord.normal_list = []
+    coord.new_list = []
+    assert coord.interpolate_states(50) == 40
+
+
+def test_interpolate_states_full_range(module):
+    """Interpolate when both start and end values are provided."""
+    coord, _ = make_coordinator(module)
+    coord.start_value = 10
+    coord.end_value = 90
+    coord.normal_list = []
+    coord.new_list = []
+    assert coord.interpolate_states(50) == 50


### PR DESCRIPTION
## Summary
- ensure interpolation uses explicit None checks
- expand interpolation tests with partial ranges

## Testing
- `scripts/lint`
- `scripts/test`


------
https://chatgpt.com/codex/tasks/task_e_6858362ef3c8832e9ab9fe90bacb95fa