### PR TITLE
Refactor config flow validation

### DIFF
--- a/custom_components/simple_auto_cover/config_flow.py
+++ b/custom_components/simple_auto_cover/config_flow.py
@@ -263,6 +263,15 @@ def _get_azimuth_edges(data) -> tuple[int, int]:
     return data[CONF_FOV_LEFT] + data[CONF_FOV_RIGHT]
 
 
+def _validate_elevation_range(user_input: dict[str, Any]) -> bool:
+    """Return True if max elevation is greater than min elevation."""
+    return not (
+        user_input.get(CONF_MAX_ELEVATION) is not None
+        and user_input.get(CONF_MIN_ELEVATION) is not None
+        and user_input[CONF_MAX_ELEVATION] <= user_input[CONF_MIN_ELEVATION]
+    )
+
+
 class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
     """Handle ConfigFlow."""
 
@@ -289,12 +298,7 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
         self.type_blind = sensor_type
 
         if user_input is not None:
-            if (
-                user_input.get(CONF_MAX_ELEVATION) is not None
-                and user_input.get(CONF_MIN_ELEVATION) is not None
-                and user_input[CONF_MAX_ELEVATION]
-                <= user_input[CONF_MIN_ELEVATION]
-            ):
+            if not _validate_elevation_range(user_input):
                 return self.async_show_form(
                     step_id=step_id,
                     data_schema=schema,
@@ -528,18 +532,14 @@ class OptionsFlowHandler(OptionsFlow):
                 CONF_MAX_ELEVATION,
             ]
             self.optional_entities(keys, user_input)
-            if (
-                user_input.get(CONF_MAX_ELEVATION) is not None
-                and user_input.get(CONF_MIN_ELEVATION) is not None
-            ):
-                if user_input[CONF_MAX_ELEVATION] <= user_input[CONF_MIN_ELEVATION]:
-                    return self.async_show_form(
-                        step_id="vertical",
-                        data_schema=VERTICAL_OPTIONS.schema,
-                        errors={
-                            CONF_MAX_ELEVATION: "Must be greater than 'Minimal Elevation'"
-                        },
-                    )
+            if not _validate_elevation_range(user_input):
+                return self.async_show_form(
+                    step_id="vertical",
+                    data_schema=VERTICAL_OPTIONS.schema,
+                    errors={
+                        CONF_MAX_ELEVATION: "Must be greater than 'Minimal Elevation'"
+                    },
+                )
             self.options.update(user_input)
             if self.options.get(CONF_INTERP, False):
                 return await self.async_step_interp()
@@ -563,18 +563,14 @@ class OptionsFlowHandler(OptionsFlow):
                 CONF_MAX_ELEVATION,
             ]
             self.optional_entities(keys, user_input)
-            if (
-                user_input.get(CONF_MAX_ELEVATION) is not None
-                and user_input.get(CONF_MIN_ELEVATION) is not None
-            ):
-                if user_input[CONF_MAX_ELEVATION] <= user_input[CONF_MIN_ELEVATION]:
-                    return self.async_show_form(
-                        step_id="horizontal",
-                        data_schema=HORIZONTAL_OPTIONS.schema,
-                        errors={
-                            CONF_MAX_ELEVATION: "Must be greater than 'Minimal Elevation'"
-                        },
-                    )
+            if not _validate_elevation_range(user_input):
+                return self.async_show_form(
+                    step_id="horizontal",
+                    data_schema=HORIZONTAL_OPTIONS.schema,
+                    errors={
+                        CONF_MAX_ELEVATION: "Must be greater than 'Minimal Elevation'"
+                    },
+                )
             self.options.update(user_input)
             return await self._update_options()
         return self.async_show_form(
@@ -594,18 +590,14 @@ class OptionsFlowHandler(OptionsFlow):
                 CONF_MAX_ELEVATION,
             ]
             self.optional_entities(keys, user_input)
-            if (
-                user_input.get(CONF_MAX_ELEVATION) is not None
-                and user_input.get(CONF_MIN_ELEVATION) is not None
-            ):
-                if user_input[CONF_MAX_ELEVATION] <= user_input[CONF_MIN_ELEVATION]:
-                    return self.async_show_form(
-                        step_id="tilt",
-                        data_schema=TILT_OPTIONS.schema,
-                        errors={
-                            CONF_MAX_ELEVATION: "Must be greater than 'Minimal Elevation'"
-                        },
-                    )
+            if not _validate_elevation_range(user_input):
+                return self.async_show_form(
+                    step_id="tilt",
+                    data_schema=TILT_OPTIONS.schema,
+                    errors={
+                        CONF_MAX_ELEVATION: "Must be greater than 'Minimal Elevation'"
+                    },
+                )
             self.options.update(user_input)
             return await self._update_options()
         return self.async_show_form(

--- a/tests/test_config_flow.py
+++ b/tests/test_config_flow.py
@@ -103,3 +103,20 @@ async def test_blind_step_validation():
     result = await handler.async_step_vertical(data)
     assert result["type"] == "form"
     assert result["errors"] == {cf.CONF_MAX_ELEVATION: "Must be greater than 'Minimal Elevation'"}
+
+
+def test_validate_elevation_range():
+    """Verify the helper correctly compares min and max elevation."""
+    params = {
+        (10, 5): True,
+        (5, 10): False,
+        (None, 5): True,
+        (10, None): True,
+    }
+    for (max_elev, min_elev), expected in params.items():
+        data = {}
+        if max_elev is not None:
+            data[cf.CONF_MAX_ELEVATION] = max_elev
+        if min_elev is not None:
+            data[cf.CONF_MIN_ELEVATION] = min_elev
+        assert cf._validate_elevation_range(data) is expected


### PR DESCRIPTION
## Summary
- centralize validation that checks max elevation is greater than min
- use the new helper in config/option steps to reduce duplication
- test the new `_validate_elevation_range` helper

## Testing
- `scripts/lint`
- `scripts/test`


------
https://chatgpt.com/codex/tasks/task_e_685a0cb1e9e8832eb2dc1b8bb57a4d4a