### PR TITLE
Refactor coordinator update handlers

### DIFF
--- a/custom_components/simple_auto_cover/coordinator.py
+++ b/custom_components/simple_auto_cover/coordinator.py
@@ -295,14 +295,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             await self.async_timed_end_time()
 
         # Handle types of changes
-        if self.state_change:
-            await self.async_handle_state_change(state, options)
-        if self.cover_state_change:
-            await self.async_handle_cover_state_change(state)
-        if self.first_refresh:
-            await self.async_handle_first_refresh(state, options)
-        if self.timed_refresh:
-            await self.async_handle_timed_refresh(options)
+        await self.async_handle_changes(state, options)
 
         normal_cover = self.normal_cover_state.cover
         # Run the solar_times method in a separate thread
@@ -344,7 +337,18 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             },
         )
 
-    async def async_handle_state_change(self, state: int, options):
+    async def async_handle_changes(self, state: int, options) -> None:
+        """Dispatch handling for the different update scenarios."""
+        if self.state_change:
+            await self.async_handle_state_change(state, options)
+        if self.cover_state_change:
+            await self.async_handle_cover_state_change(state)
+        if self.first_refresh:
+            await self.async_handle_first_refresh(state, options)
+        if self.timed_refresh:
+            await self.async_handle_timed_refresh(options)
+
+    async def async_handle_state_change(self, state: int, options) -> None:
         """Handle state change from tracked entities."""
         if self.control_toggle:
             for cover in self.entities:
@@ -354,7 +358,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         self.state_change = False
         self.logger.debug("State change handled")
 
-    async def async_handle_cover_state_change(self, state: int):
+    async def async_handle_cover_state_change(self, state: int) -> None:
         """Handle state change from assigned covers."""
         if self.manual_toggle and self.control_toggle:
             self.manager.handle_state_change(
@@ -368,7 +372,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         self.cover_state_change = False
         self.logger.debug("Cover state change handled")
 
-    async def async_handle_first_refresh(self, state: int, options):
+    async def async_handle_first_refresh(self, state: int, options) -> None:
         """Handle first refresh."""
         if self.control_toggle:
             for cover in self.entities:
@@ -383,7 +387,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         self.first_refresh = False
         self.logger.debug("First refresh handled")
 
-    async def async_handle_timed_refresh(self, options):
+    async def async_handle_timed_refresh(self, options) -> None:
         """Handle timed refresh."""
         self.logger.debug(
             "This is a timed refresh, using sunset position: %s",
@@ -404,8 +408,8 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         self.timed_refresh = False
         self.logger.debug("Timed refresh handled")
 
-    async def async_handle_call_service(self, entity, state: int, options):
-        """Handle call service."""
+    async def async_handle_call_service(self, entity, state: int, options) -> None:
+        """Call the appropriate service for state changes."""
         if (
             self.check_adaptive_time
             and self.check_position_delta(entity, state, options)


### PR DESCRIPTION
## Summary
- break up `_async_update_data` change handling into helper methods
- restore `async_` prefixes for all handler helpers to follow project style

## Testing
- `scripts/lint`
- `scripts/test`


------
https://chatgpt.com/codex/tasks/task_e_685a0d22ef18832eb7c7c0ad20b09399