### PR TITLE
Replace pytz with zoneinfo

### DIFF
--- a/custom_components/simple_auto_cover/coordinator.py
+++ b/custom_components/simple_auto_cover/coordinator.py
@@ -7,7 +7,7 @@ import datetime as dt
 from dataclasses import dataclass
 
 import numpy as np
-import pytz
+from homeassistant.util import dt as dt_util
 from homeassistant.components.cover import DOMAIN as COVER_DOMAIN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
@@ -300,7 +300,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         if (
             self.first_refresh
             or self._sun_start_time is None
-            or dt.datetime.now(pytz.UTC).date() != self._sun_start_time.date()
+            or dt_util.utcnow().date() != self._sun_start_time.date()
         ):
             self.logger.debug("Calculating solar times")
             loop = asyncio.get_running_loop()
@@ -598,7 +598,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
 
     def check_time_delta(self, entity):
         """Check if time delta is passed."""
-        now = dt.datetime.now(dt.UTC)
+        now = dt_util.utcnow()
         last_updated = get_last_updated(entity, self.hass)
         if last_updated is not None:
             condition = now - last_updated >= dt.timedelta(minutes=self.time_threshold)

--- a/custom_components/simple_auto_cover/cover_manager.py
+++ b/custom_components/simple_auto_cover/cover_manager.py
@@ -3,6 +3,7 @@
 from __future__ import annotations
 
 import datetime as dt
+from homeassistant.util import dt as dt_util
 
 from .const import SensorType
 
@@ -99,7 +100,7 @@ class AdaptiveCoverManager:
 
     async def reset_if_needed(self) -> None:
         """Reset manual control state of the covers."""
-        current_time = dt.datetime.now(dt.UTC)
+        current_time = dt_util.utcnow()
         manual_control_time_copy = dict(self.manual_control_time)
         for entity_id, last_updated in manual_control_time_copy.items():
             if current_time - last_updated > self.reset_duration:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,7 +33,6 @@ pytest = "8.3.5"
 pytest-homeassistant-custom-component = "0.13.252"
 numpy = "*"
 pandas = "*"
-pytz = "*"
 python-dateutil = "*"
 
 [tool.poetry.urls]

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -9,5 +9,4 @@ pytest==8.3.5
 pytest-homeassistant-custom-component==0.13.252
 numpy
 pandas
-pytz
 python-dateutil


### PR DESCRIPTION
## Summary
- remove pytz in dev dependencies
- use Home Assistant `dt_util` helpers for UTC timestamps

## Testing
- `scripts/lint`
- `scripts/test`


------
https://chatgpt.com/codex/tasks/task_e_685a15f7034c832e9242a83fa80e0288