### PR TITLE
Refactor solar utilities and drop pandas

### DIFF
--- a/custom_components/simple_auto_cover/calculation.py
+++ b/custom_components/simple_auto_cover/calculation.py
@@ -5,7 +5,6 @@ from dataclasses import dataclass, field
 from datetime import datetime, timedelta
 
 import numpy as np
-import pandas as pd
 from homeassistant.core import HomeAssistant
 from numpy import cos, sin, tan
 from numpy import radians as rad
@@ -47,28 +46,21 @@ class AdaptiveGeneralCover(ABC):
         self.sun_data = SunData(self.timezone, self.hass)
 
     def solar_times(self):
-        """Determine start/end times."""
-        df_today = pd.DataFrame(
-            {
-                "azimuth": self.sun_data.solar_azimuth,
-                "elevation": self.sun_data.solar_elevation,
-            }
-        )
-        solpos = df_today.set_index(self.sun_data.times)
+        """Determine the first and last valid sun positions."""
+        times = self.sun_data.times
+        azimuths = self.sun_data.solar_azimuth
+        elevations = self.sun_data.solar_elevation
 
-        alpha = solpos["azimuth"]
-        frame = (
-            (alpha - self.azi_min_abs) % 360
-            <= (self.azi_max_abs - self.azi_min_abs) % 360
-        ) & (solpos["elevation"] > 0)
+        filtered_times = [
+            t
+            for t, az, el in zip(times, azimuths, elevations)
+            if ((az - self.azi_min_abs) % 360 <= (self.azi_max_abs - self.azi_min_abs) % 360) and el > 0
+        ]
 
-        if solpos[frame].empty:
+        if not filtered_times:
             return None, None
-        else:
-            return (
-                solpos[frame].index[0].to_pydatetime(),
-                solpos[frame].index[-1].to_pydatetime(),
-            )
+
+        return filtered_times[0], filtered_times[-1]
 
     @property
     def _get_azimuth_edges(self) -> tuple[int, int]:

--- a/custom_components/simple_auto_cover/manifest.json
+++ b/custom_components/simple_auto_cover/manifest.json
@@ -7,6 +7,6 @@
   "documentation": "https://github.com/travisp/adaptive-cover",
   "iot_class": "calculated",
   "issue_tracker": "https://github.com/travisp/adaptive-cover/issues",
-  "requirements": ["astral", "pandas"],
+  "requirements": ["astral"],
   "version": "0.3.0b0"
 }

--- a/custom_components/simple_auto_cover/sun.py
+++ b/custom_components/simple_auto_cover/sun.py
@@ -1,8 +1,7 @@
 """Fetch sun data."""
 
 from datetime import date, datetime, timedelta
-
-import pandas as pd
+from zoneinfo import ZoneInfo
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.sun import get_astral_location
 
@@ -15,17 +14,21 @@ class SunData:
         location, elevation = get_astral_location(self.hass)
         self.location = location  # astral.location.Location
         self.elevation = elevation
-        self.timezone = timezone
+        self.timezone = ZoneInfo(str(timezone))
 
     @property
-    def times(self) -> pd.DatetimeIndex:
-        """Define time interval."""
+    def times(self) -> list[datetime]:
+        """Return 5 minute intervals from midnight today to tomorrow."""
         start_date = date.today()
         end_date = start_date + timedelta(days=1)
+        start_time = datetime.combine(start_date, datetime.min.time(), tzinfo=self.timezone)
+        end_time = datetime.combine(end_date, datetime.min.time(), tzinfo=self.timezone)
 
-        times = pd.date_range(
-            start=start_date, end=end_date, freq="5min", tz=self.timezone, name="time"
-        )
+        times = []
+        current_time = start_time
+        while current_time <= end_time:
+            times.append(current_time)
+            current_time += timedelta(minutes=5)
         return times
 
     @property

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ ruff = "0.6.9"
 pytest = "8.3.5"
 pytest-homeassistant-custom-component = "0.13.252"
 numpy = "*"
-pandas = "*"
 pytz = "*"
 python-dateutil = "*"
 

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -8,6 +8,5 @@ ipykernel~=6.29
 pytest==8.3.5
 pytest-homeassistant-custom-component==0.13.252
 numpy
-pandas
 pytz
 python-dateutil

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,2 @@
 homeassistant==2025.6.1
 pip>=24.1.1,<24.3
-pandas~=2.2

--- a/tests/test_solar_times.py
+++ b/tests/test_solar_times.py
@@ -1,0 +1,63 @@
+"""Tests for AdaptiveGeneralCover.solar_times."""
+
+from __future__ import annotations
+
+import types
+import datetime as dt
+
+import custom_components.simple_auto_cover.calculation as calculation
+
+
+def test_solar_times_returns_first_and_last_valid(monkeypatch):
+    """Validate filtering of times based on azimuth and elevation."""
+
+    base = dt.datetime(2025, 1, 1, tzinfo=dt.UTC)
+    times = [base + dt.timedelta(minutes=5 * i) for i in range(5)]
+    azimuths = [60, 80, 90, 100, 120]
+    elevations = [-1, 10, 20, 20, -1]
+
+    sun_data = types.SimpleNamespace(
+        times=times, solar_azimuth=azimuths, solar_elevation=elevations
+    )
+
+    class DummyCover(calculation.AdaptiveGeneralCover):
+        __test__ = False
+
+        def __post_init__(self):
+            self.sun_data = sun_data
+
+        def calculate_position(self) -> float:
+            return 0.0
+
+        def calculate_percentage(self) -> int:
+            return 0
+
+    cover = DummyCover(
+        hass=None,
+        logger=types.SimpleNamespace(debug=lambda *a, **k: None),
+        sol_azi=0,
+        sol_elev=0,
+        sunset_pos=0,
+        sunset_off=0,
+        sunrise_off=0,
+        timezone="UTC",
+        fov_left=20,
+        fov_right=20,
+        win_azi=90,
+        h_def=0,
+        max_pos=100,
+        min_pos=0,
+        max_pos_bool=False,
+        min_pos_bool=False,
+        blind_spot_left=None,
+        blind_spot_right=None,
+        blind_spot_elevation=None,
+        blind_spot_on=False,
+        min_elevation=None,
+        max_elevation=None,
+    )
+
+    start, end = cover.solar_times()
+
+    assert start == times[1]
+    assert end == times[3]

--- a/tests/test_sun.py
+++ b/tests/test_sun.py
@@ -38,3 +38,51 @@ def test_solar_azimuth_and_elevation(monkeypatch):
     assert sun_data.solar_elevation == [t.minute - 5 for t in times]
     assert az_calls == [(t, 5) for t in times]
     assert el_calls == [(t, 5) for t in times]
+
+
+def test_times_range(monkeypatch):
+    """Ensure times covers a full day in 5 minute increments."""
+
+    def dummy_get_astral_location(hass):
+        return types.SimpleNamespace(), 0
+
+    monkeypatch.setattr(sun, "get_astral_location", dummy_get_astral_location)
+
+    sun_data = sun.SunData("UTC", types.SimpleNamespace())
+    times = sun_data.times
+
+    assert len(times) == 289
+    assert times[0].minute == 0 and times[0].hour == 0
+    assert times[-1] - times[0] == dt.timedelta(days=1)
+    assert all(t.tzinfo is not None for t in times)
+
+
+def test_times_are_five_minute_steps(monkeypatch):
+    """Verify consecutive times differ by exactly five minutes."""
+
+    def dummy_get_astral_location(hass):
+        return types.SimpleNamespace(), 0
+
+    monkeypatch.setattr(sun, "get_astral_location", dummy_get_astral_location)
+
+    sun_data = sun.SunData("UTC", types.SimpleNamespace())
+    times = sun_data.times
+
+    deltas = [b - a for a, b in zip(times, times[1:])]
+    assert all(delta == dt.timedelta(minutes=5) for delta in deltas)
+
+
+def test_timezone_is_zoneinfo(monkeypatch):
+    """Ensure timezone is stored as a ``ZoneInfo`` instance."""
+
+    def dummy_get_astral_location(hass):
+        return types.SimpleNamespace(), 0
+
+    monkeypatch.setattr(sun, "get_astral_location", dummy_get_astral_location)
+
+    sun_data = sun.SunData("UTC", types.SimpleNamespace())
+
+    from zoneinfo import ZoneInfo
+
+    assert isinstance(sun_data.timezone, ZoneInfo)
+    assert sun_data.timezone.key == "UTC"


### PR DESCRIPTION
## Summary
- remove pandas from package requirements
- simplify solar data handling with builtin datetime
- update calculation logic to work without DataFrames
- add regression test for time range calculation
- expand tests for solar utilities and filtering logic

## Testing
- `scripts/lint`
- `scripts/test`


------
https://chatgpt.com/codex/tasks/task_e_685a1592f388832ebd5da8651964ba62