### PR TITLE
Use configuration constants consistently

### DIFF
--- a/custom_components/simple_auto_cover/__init__.py
+++ b/custom_components/simple_auto_cover/__init__.py
@@ -3,7 +3,7 @@
 from __future__ import annotations
 
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import Platform
+from homeassistant.const import CONF_NAME, Platform
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.event import (
     async_track_state_change_event,
@@ -48,7 +48,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
     if _end_time_entity is not None:
         _entities.append(_end_time_entity)
 
-    _LOGGER.debug("Setting up entry %s", entry.data.get("name"))
+    _LOGGER.debug("Setting up entry %s", entry.data.get(CONF_NAME))
 
     entry.async_on_unload(
         async_track_state_change_event(

--- a/custom_components/simple_auto_cover/config_flow.py
+++ b/custom_components/simple_auto_cover/config_flow.py
@@ -14,6 +14,7 @@ from homeassistant.core import callback
 from homeassistant.data_entry_flow import FlowResult
 from homeassistant.helpers import selector
 
+from homeassistant.const import CONF_NAME
 from .const import (
     CONF_AWNING_ANGLE,
     CONF_AZIMUTH,
@@ -58,6 +59,7 @@ from .const import (
     CONF_TILT_MODE,
     DOMAIN,
     COVER_TYPE_DISPLAY,
+    STRATEGY_MODE_BASIC,
     SensorType,
     CONF_MIN_POSITION,
     CONF_ENABLE_MAX_POSITION,
@@ -71,7 +73,7 @@ SENSOR_TYPE_MENU = [SensorType.BLIND, SensorType.AWNING, SensorType.TILT]
 
 CONFIG_SCHEMA = vol.Schema(
     {
-        vol.Required("name"): selector.TextSelector(),
+        vol.Required(CONF_NAME): selector.TextSelector(),
         vol.Optional(CONF_MODE): selector.SelectSelector(
             selector.SelectSelectorConfig(
                 options=SENSOR_TYPE_MENU, translation_key="mode"
@@ -270,7 +272,7 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
         super().__init__()
         self.type_blind: str | None = None
         self.config: dict[str, Any] = {}
-        self.mode: str = "basic"
+        self.mode: str = STRATEGY_MODE_BASIC
 
     @staticmethod
     @callback
@@ -417,9 +419,9 @@ class ConfigFlowHandler(ConfigFlow, domain=DOMAIN):
     async def async_step_update(self, user_input: dict[str, Any] | None = None):
         """Create entry."""
         return self.async_create_entry(
-            title=f"{COVER_TYPE_DISPLAY[self.type_blind]} {self.config['name']}",
+            title=f"{COVER_TYPE_DISPLAY[self.type_blind]} {self.config[CONF_NAME]}",
             data={
-                "name": self.config["name"],
+                CONF_NAME: self.config[CONF_NAME],
                 CONF_SENSOR_TYPE: self.type_blind,
             },
             options={

--- a/custom_components/simple_auto_cover/coordinator.py
+++ b/custom_components/simple_auto_cover/coordinator.py
@@ -12,6 +12,7 @@ from homeassistant.components.cover import DOMAIN as COVER_DOMAIN
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.const import (
     ATTR_ENTITY_ID,
+    CONF_NAME,
     SERVICE_SET_COVER_POSITION,
     SERVICE_SET_COVER_TILT_POSITION,
 )
@@ -80,6 +81,7 @@ from .const import (
     CONF_TILT_DEPTH,
     CONF_TILT_DISTANCE,
     CONF_TILT_MODE,
+    CONF_SENSOR_TYPE,
     DOMAIN,
     LOGGER,
     SensorType,
@@ -115,8 +117,8 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         super().__init__(hass, LOGGER, name=DOMAIN)
 
         self.logger = ConfigContextAdapter(_LOGGER)
-        self.logger.set_config_name(self.config_entry.data.get("name"))
-        self._cover_type = self.config_entry.data.get("sensor_type")
+        self.logger.set_config_name(self.config_entry.data.get(CONF_NAME))
+        self._cover_type = self.config_entry.data.get(CONF_SENSOR_TYPE)
         self._inverse_state = self.config_entry.options.get(CONF_INVERSE_STATE, False)
         self._use_interpolation = self.config_entry.options.get(CONF_INTERP, False)
         self._track_end_time = self.config_entry.options.get(CONF_RETURN_SUNSET)

--- a/custom_components/simple_auto_cover/entity.py
+++ b/custom_components/simple_auto_cover/entity.py
@@ -2,6 +2,7 @@
 
 from __future__ import annotations
 
+from homeassistant.const import CONF_NAME
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
@@ -22,7 +23,7 @@ class AdaptiveCoverEntity(CoordinatorEntity[AdaptiveDataUpdateCoordinator]):
         super().__init__(coordinator=coordinator)
         self.type = COVER_TYPE_DISPLAY
         self.config_entry = config_entry
-        self._name = config_entry.data["name"]
+        self._name = config_entry.data[CONF_NAME]
         self._device_id = unique_id
         self._device_name = self.type[config_entry.data[CONF_SENSOR_TYPE]]
         self._attr_device_info = DeviceInfo(

--- a/custom_components/simple_auto_cover/sensor.py
+++ b/custom_components/simple_auto_cover/sensor.py
@@ -11,13 +11,13 @@ from homeassistant.components.sensor import (
     SensorStateClass,
 )
 from homeassistant.config_entries import ConfigEntry
-from homeassistant.const import PERCENTAGE
+from homeassistant.const import CONF_NAME, PERCENTAGE
 from homeassistant.core import HomeAssistant, callback
 from homeassistant.helpers.device_registry import DeviceEntryType
 from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .const import DOMAIN
+from .const import CONF_SENSOR_TYPE, DOMAIN
 from .coordinator import AdaptiveDataUpdateCoordinator
 from .entity import AdaptiveCoverEntity
 
@@ -29,7 +29,7 @@ async def async_setup_entry(
 ) -> None:
     """Initialize Simple Auto Cover config entry."""
 
-    name = config_entry.data["name"]
+    name = config_entry.data[CONF_NAME]
     coordinator: AdaptiveDataUpdateCoordinator = hass.data[DOMAIN][
         config_entry.entry_id
     ]
@@ -145,7 +145,7 @@ class AdaptiveCoverTimeSensorEntity(AdaptiveCoverEntity, SensorEntity):
         self.hass = hass
         self.config_entry = config_entry
         self._name = name
-        self._cover_type = self.config_entry.data["sensor_type"]
+        self._cover_type = self.config_entry.data[CONF_SENSOR_TYPE]
         self._sensor_name = sensor_name
         self._attr_device_info = DeviceInfo(
             entry_type=DeviceEntryType.SERVICE,
@@ -197,7 +197,7 @@ class AdaptiveCoverControlSensorEntity(AdaptiveCoverEntity, SensorEntity):
         self.hass = hass
         self.config_entry = config_entry
         self._name = name
-        self._cover_type = self.config_entry.data["sensor_type"]
+        self._cover_type = self.config_entry.data[CONF_SENSOR_TYPE]
         self._attr_device_info = DeviceInfo(
             entry_type=DeviceEntryType.SERVICE,
             identifiers={(DOMAIN, self._device_id)},

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -4,7 +4,14 @@ import types
 import pytest
 
 from tests.conftest import import_module
-from custom_components.simple_auto_cover import const
+from homeassistant.const import CONF_NAME
+from custom_components.simple_auto_cover.const import (
+    CONF_ENTITIES,
+    CONF_SENSOR_TYPE,
+    COVER_TYPE_DISPLAY,
+    DOMAIN,
+    SensorType,
+)
 
 
 @pytest.fixture
@@ -77,8 +84,8 @@ class DummyCoordinator:
 def make_entry(*, name="Test", sensor_type=None):
     """Create a simple config entry namespace for tests."""
     return types.SimpleNamespace(
-        data={"name": name, const.CONF_SENSOR_TYPE: sensor_type or const.SensorType.BLIND},
-        options={const.CONF_ENTITIES: ["cover.one"]},
+        data={CONF_NAME: name, CONF_SENSOR_TYPE: sensor_type or SensorType.BLIND},
+        options={CONF_ENTITIES: ["cover.one"]},
         entry_id="1",
     )
 
@@ -89,9 +96,9 @@ def test_base_entity_initialization(entity_module):
     entity = entity_module.AdaptiveCoverEntity(entry, "uid", coord)
 
     assert entity._device_id == "uid"
-    assert entity._name == entry.data["name"]
-    assert entity._device_name == const.COVER_TYPE_DISPLAY[entry.data[const.CONF_SENSOR_TYPE]]
-    assert entity.device_info["identifiers"] == {(const.DOMAIN, "uid")}
+    assert entity._name == entry.data[CONF_NAME]
+    assert entity._device_name == COVER_TYPE_DISPLAY[entry.data[CONF_SENSOR_TYPE]]
+    assert entity.device_info["identifiers"] == {(DOMAIN, "uid")}
 
 
 def test_button_inherits_base(entity_module, button_module):
@@ -101,8 +108,8 @@ def test_button_inherits_base(entity_module, button_module):
     button = button_module.AdaptiveCoverButton(entry, "uid", "Reset", coord)
 
     assert isinstance(button, entity_module.AdaptiveCoverEntity)
-    assert button.name == "Reset " + entry.data["name"]
-    assert button.device_info["name"] == const.COVER_TYPE_DISPLAY[entry.data[const.CONF_SENSOR_TYPE]]
+    assert button.name == "Reset " + entry.data[CONF_NAME]
+    assert button.device_info["name"] == COVER_TYPE_DISPLAY[entry.data[CONF_SENSOR_TYPE]]
     assert button.unique_id == "uid_Reset"
 
 
@@ -122,7 +129,7 @@ def test_binary_sensor_is_on(entity_module, binary_sensor_module):
 
     assert isinstance(sensor, entity_module.AdaptiveCoverEntity)
     assert sensor.is_on is True
-    assert sensor.name == "Sun " + entry.data["name"]
+    assert sensor.name == "Sun " + entry.data[CONF_NAME]
     assert sensor.unique_id == "uid_Sun"
 
 
@@ -132,7 +139,7 @@ def test_sensor_native_value(entity_module, sensor_module):
     states = {"state": 55, "start": "2025-01-01", "end": "2025-01-02", "control": "auto"}
     coord = DummyCoordinator(states=states, attrs={"foo": "bar"})
 
-    sensor = sensor_module.AdaptiveCoverSensorEntity("uid", None, entry, entry.data["name"], coord)
+    sensor = sensor_module.AdaptiveCoverSensorEntity("uid", None, entry, entry.data[CONF_NAME], coord)
     assert sensor.native_value == 55
     assert sensor.extra_state_attributes == {"foo": "bar"}
 
@@ -140,7 +147,7 @@ def test_sensor_native_value(entity_module, sensor_module):
         "uid",
         None,
         entry,
-        entry.data["name"],
+        entry.data[CONF_NAME],
         "Start Sun",
         "start",
         "icon",
@@ -148,7 +155,7 @@ def test_sensor_native_value(entity_module, sensor_module):
     )
     assert time_sensor.native_value == states["start"]
 
-    control_sensor = sensor_module.AdaptiveCoverControlSensorEntity("uid", None, entry, entry.data["name"], coord)
+    control_sensor = sensor_module.AdaptiveCoverControlSensorEntity("uid", None, entry, entry.data[CONF_NAME], coord)
     assert control_sensor.native_value == "auto"
 
 
@@ -159,5 +166,5 @@ def test_switch_initial_state(entity_module, switch_module):
     switch = switch_module.AdaptiveCoverSwitch(entry, "uid", "Manual", True, "manual_toggle", coord)
 
     assert isinstance(switch, entity_module.AdaptiveCoverEntity)
-    assert switch.name == "Manual " + entry.data["name"]
+    assert switch.name == "Manual " + entry.data[CONF_NAME]
     assert switch.unique_id == "uid_Manual"


### PR DESCRIPTION
## Summary
- import `CONF_ENTITIES`, `CONF_SENSOR_TYPE`, `COVER_TYPE_DISPLAY`, `DOMAIN`, and `SensorType` directly in entity tests
- update test references to use these constants directly

## Testing
- `scripts/lint`
- `scripts/test`


------
https://chatgpt.com/codex/tasks/task_e_685a11962320832e9578681d29bbff2c