### PR TITLE
Introduce CoverConfig dataclass

### DIFF
--- a/custom_components/simple_auto_cover/calculation.py
+++ b/custom_components/simple_auto_cover/calculation.py
@@ -15,6 +15,37 @@ from .config_context_adapter import ConfigContextAdapter
 
 
 @dataclass
+class CoverConfig:
+    """Parameters for adaptive cover calculations."""
+
+    sunset_pos: int | None = 0
+    sunset_off: int | None = 0
+    sunrise_off: int | None = 0
+    timezone: str | None = "UTC"
+    fov_left: int | None = 0
+    fov_right: int | None = 0
+    win_azi: int | None = 0
+    h_def: int | None = 0
+    max_pos: int | None = 100
+    min_pos: int | None = 0
+    max_pos_bool: bool | None = False
+    min_pos_bool: bool | None = False
+    blind_spot_left: int | None = None
+    blind_spot_right: int | None = None
+    blind_spot_elevation: int | None = None
+    blind_spot_on: bool | None = False
+    min_elevation: int | None = None
+    max_elevation: int | None = None
+    distance: float | None = None
+    h_win: float | None = None
+    awn_length: float | None = None
+    awn_angle: float | None = None
+    slat_distance: float | None = None
+    depth: float | None = None
+    mode: str | None = None
+
+
+@dataclass(init=False)
 class AdaptiveGeneralCover(ABC):
     """Collect common data."""
 
@@ -41,6 +72,39 @@ class AdaptiveGeneralCover(ABC):
     min_elevation: int
     max_elevation: int
     sun_data: SunData = field(init=False)
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        logger: ConfigContextAdapter,
+        sol_azi: float,
+        sol_elev: float,
+        config: CoverConfig,
+    ) -> None:
+        """Initialize with environment and configuration."""
+        self.hass = hass
+        self.logger = logger
+        self.sol_azi = sol_azi
+        self.sol_elev = sol_elev
+        self.sunset_pos = config.sunset_pos
+        self.sunset_off = config.sunset_off
+        self.sunrise_off = config.sunrise_off
+        self.timezone = config.timezone
+        self.fov_left = config.fov_left
+        self.fov_right = config.fov_right
+        self.win_azi = config.win_azi
+        self.h_def = config.h_def
+        self.max_pos = config.max_pos
+        self.min_pos = config.min_pos
+        self.max_pos_bool = config.max_pos_bool
+        self.min_pos_bool = config.min_pos_bool
+        self.blind_spot_left = config.blind_spot_left
+        self.blind_spot_right = config.blind_spot_right
+        self.blind_spot_elevation = config.blind_spot_elevation
+        self.blind_spot_on = config.blind_spot_on
+        self.min_elevation = config.min_elevation
+        self.max_elevation = config.max_elevation
+        self.__post_init__()
 
     def __post_init__(self):
         """Add solar data to dataset."""
@@ -226,12 +290,25 @@ class NormalCoverState:
         return result
 
 
-@dataclass
+@dataclass(init=False)
 class AdaptiveVerticalCover(AdaptiveGeneralCover):
     """Calculate state for Vertical blinds."""
 
     distance: float
     h_win: float
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        logger: ConfigContextAdapter,
+        sol_azi: float,
+        sol_elev: float,
+        config: CoverConfig,
+    ) -> None:
+        """Initialize vertical cover parameters."""
+        super().__init__(hass, logger, sol_azi, sol_elev, config)
+        self.distance = config.distance
+        self.h_win = config.h_win
 
     def calculate_position(self) -> float:
         """Calculate blind height."""
@@ -253,12 +330,25 @@ class AdaptiveVerticalCover(AdaptiveGeneralCover):
         return round(result)
 
 
-@dataclass
+@dataclass(init=False)
 class AdaptiveHorizontalCover(AdaptiveVerticalCover):
     """Calculate state for Horizontal blinds."""
 
     awn_length: float
     awn_angle: float
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        logger: ConfigContextAdapter,
+        sol_azi: float,
+        sol_elev: float,
+        config: CoverConfig,
+    ) -> None:
+        """Initialize horizontal cover parameters."""
+        super().__init__(hass, logger, sol_azi, sol_elev, config)
+        self.awn_length = config.awn_length
+        self.awn_angle = config.awn_angle
 
     def calculate_position(self) -> float:
         """Calculate awn length from blind height."""
@@ -279,13 +369,27 @@ class AdaptiveHorizontalCover(AdaptiveVerticalCover):
         return round(result)
 
 
-@dataclass
+@dataclass(init=False)
 class AdaptiveTiltCover(AdaptiveGeneralCover):
     """Calculate state for tilted blinds."""
 
     slat_distance: float
     depth: float
     mode: str
+
+    def __init__(
+        self,
+        hass: HomeAssistant,
+        logger: ConfigContextAdapter,
+        sol_azi: float,
+        sol_elev: float,
+        config: CoverConfig,
+    ) -> None:
+        """Initialize tilt cover parameters."""
+        super().__init__(hass, logger, sol_azi, sol_elev, config)
+        self.slat_distance = config.slat_distance
+        self.depth = config.depth
+        self.mode = config.mode
 
     @property
     def beta(self):

--- a/custom_components/simple_auto_cover/coordinator.py
+++ b/custom_components/simple_auto_cover/coordinator.py
@@ -33,6 +33,7 @@ from .calculation import (
     AdaptiveTiltCover,
     AdaptiveVerticalCover,
     NormalCoverState,
+    CoverConfig,
 )
 from .const import (
     _LOGGER,
@@ -467,30 +468,32 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
 
     def get_blind_data(self, options):
         """Assign correct class for type of blind."""
+        config = CoverConfig()
+        self.common_data(options, config)
         if self._cover_type == SensorType.BLIND:
+            self.vertical_data(options, config)
             cover_data = AdaptiveVerticalCover(
                 self.hass,
                 self.logger,
                 *self.pos_sun,
-                *self.common_data(options),
-                *self.vertical_data(options),
+                config,
             )
         if self._cover_type == SensorType.AWNING:
+            self.vertical_data(options, config)
+            self.horizontal_data(options, config)
             cover_data = AdaptiveHorizontalCover(
                 self.hass,
                 self.logger,
                 *self.pos_sun,
-                *self.common_data(options),
-                *self.vertical_data(options),
-                *self.horizontal_data(options),
+                config,
             )
         if self._cover_type == SensorType.TILT:
+            self.tilt_data(options, config)
             cover_data = AdaptiveTiltCover(
                 self.hass,
                 self.logger,
                 *self.pos_sun,
-                *self.common_data(options),
-                *self.tilt_data(options),
+                config,
             )
         return cover_data
 
@@ -614,50 +617,48 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             state_attr(self.hass, "sun.sun", "elevation"),
         ]
 
-    def common_data(self, options):
+    def common_data(self, options, config):
         """Update shared parameters."""
-        return [
-            options.get(CONF_SUNSET_POS),
-            options.get(CONF_SUNSET_OFFSET),
-            options.get(CONF_SUNRISE_OFFSET, options.get(CONF_SUNSET_OFFSET)),
-            self.hass.config.time_zone,
-            options.get(CONF_FOV_LEFT),
-            options.get(CONF_FOV_RIGHT),
-            options.get(CONF_AZIMUTH),
-            options.get(CONF_DEFAULT_HEIGHT),
-            options.get(CONF_MAX_POSITION),
-            options.get(CONF_MIN_POSITION),
-            options.get(CONF_ENABLE_MAX_POSITION, False),
-            options.get(CONF_ENABLE_MIN_POSITION, False),
-            options.get(CONF_BLIND_SPOT_LEFT),
-            options.get(CONF_BLIND_SPOT_RIGHT),
-            options.get(CONF_BLIND_SPOT_ELEVATION),
-            options.get(CONF_ENABLE_BLIND_SPOT, False),
-            options.get(CONF_MIN_ELEVATION, None),
-            options.get(CONF_MAX_ELEVATION, None),
-        ]
+        config.sunset_pos = options.get(CONF_SUNSET_POS)
+        config.sunset_off = options.get(CONF_SUNSET_OFFSET)
+        config.sunrise_off = options.get(
+            CONF_SUNRISE_OFFSET, options.get(CONF_SUNSET_OFFSET)
+        )
+        config.timezone = self.hass.config.time_zone
+        config.fov_left = options.get(CONF_FOV_LEFT)
+        config.fov_right = options.get(CONF_FOV_RIGHT)
+        config.win_azi = options.get(CONF_AZIMUTH)
+        config.h_def = options.get(CONF_DEFAULT_HEIGHT)
+        config.max_pos = options.get(CONF_MAX_POSITION)
+        config.min_pos = options.get(CONF_MIN_POSITION)
+        config.max_pos_bool = options.get(CONF_ENABLE_MAX_POSITION, False)
+        config.min_pos_bool = options.get(CONF_ENABLE_MIN_POSITION, False)
+        config.blind_spot_left = options.get(CONF_BLIND_SPOT_LEFT)
+        config.blind_spot_right = options.get(CONF_BLIND_SPOT_RIGHT)
+        config.blind_spot_elevation = options.get(CONF_BLIND_SPOT_ELEVATION)
+        config.blind_spot_on = options.get(CONF_ENABLE_BLIND_SPOT, False)
+        config.min_elevation = options.get(CONF_MIN_ELEVATION, None)
+        config.max_elevation = options.get(CONF_MAX_ELEVATION, None)
+        return config
 
-    def vertical_data(self, options):
+    def vertical_data(self, options, config):
         """Update data for vertical blinds."""
-        return [
-            options.get(CONF_DISTANCE),
-            options.get(CONF_HEIGHT_WIN),
-        ]
+        config.distance = options.get(CONF_DISTANCE)
+        config.h_win = options.get(CONF_HEIGHT_WIN)
+        return config
 
-    def horizontal_data(self, options):
+    def horizontal_data(self, options, config):
         """Update data for horizontal blinds."""
-        return [
-            options.get(CONF_LENGTH_AWNING),
-            options.get(CONF_AWNING_ANGLE),
-        ]
+        config.awn_length = options.get(CONF_LENGTH_AWNING)
+        config.awn_angle = options.get(CONF_AWNING_ANGLE)
+        return config
 
-    def tilt_data(self, options):
+    def tilt_data(self, options, config):
         """Update data for tilted blinds."""
-        return [
-            options.get(CONF_TILT_DISTANCE),
-            options.get(CONF_TILT_DEPTH),
-            options.get(CONF_TILT_MODE),
-        ]
+        config.slat_distance = options.get(CONF_TILT_DISTANCE)
+        config.depth = options.get(CONF_TILT_DEPTH)
+        config.mode = options.get(CONF_TILT_MODE)
+        return config
 
     @property
     def state(self) -> int:

--- a/tests/test_calculation.py
+++ b/tests/test_calculation.py
@@ -51,19 +51,20 @@ class TestVerticalCover:
             "h_win": 2,
             "logger": types.SimpleNamespace(debug=lambda *a, **k: None),
         }
-        if (
-            hasattr(
-                calculation_module.AdaptiveVerticalCover,
-                "__dataclass_fields__",
-            )
-            and "logger"
-            in calculation_module.AdaptiveVerticalCover.__dataclass_fields__
-        ):
-            defaults.setdefault(
-                "logger", types.SimpleNamespace(debug=lambda *a, **k: None)
-            )
         defaults.update(kwargs)
-        cover = DummyCover(**defaults)
+        config_kwargs = {
+            key: defaults[key]
+            for key in calculation_module.CoverConfig.__dataclass_fields__
+            if key in defaults
+        }
+        config = calculation_module.CoverConfig(**config_kwargs)
+        cover = DummyCover(
+            defaults["hass"],
+            defaults["logger"],
+            defaults["sol_azi"],
+            defaults["sol_elev"],
+            config,
+        )
         cover.sun_data = None
         return cover
 

--- a/tests/test_sunset_final.py
+++ b/tests/test_sunset_final.py
@@ -64,7 +64,19 @@ class TestVerticalCover:
             "logger": types.SimpleNamespace(debug=lambda *a, **k: None),
         }
         defaults.update(kwargs)
-        cover = DummyCover(**defaults)
+        config_kwargs = {
+            key: defaults[key]
+            for key in module.CoverConfig.__dataclass_fields__
+            if key in defaults
+        }
+        config = module.CoverConfig(**config_kwargs)
+        cover = DummyCover(
+            defaults["hass"],
+            defaults["logger"],
+            defaults["sol_azi"],
+            defaults["sol_elev"],
+            config,
+        )
         cover.sun_data = None
         return cover
 


### PR DESCRIPTION
## Summary
- consolidate cover parameters into new `CoverConfig` dataclass
- update calculation classes to accept the new dataclass
- adapt coordinator helpers to populate `CoverConfig`
- update tests for new class signatures

## Testing
- `scripts/lint`
- `scripts/test` *(fails: pre-commit cannot install node due to network restrictions)*

------
https://chatgpt.com/codex/tasks/task_e_685836424868832eb7123b987dfc0c70