### PR TITLE
Fix tests without stubbing numpy

### DIFF
--- a/custom_components/simple_auto_cover/calculation.py
+++ b/custom_components/simple_auto_cover/calculation.py
@@ -118,7 +118,11 @@ class AdaptiveGeneralCover(ABC):
         filtered_times = [
             t
             for t, az, el in zip(times, azimuths, elevations)
-            if ((az - self.azi_min_abs) % 360 <= (self.azi_max_abs - self.azi_min_abs) % 360) and el > 0
+            if (
+                (az - self.azi_min_abs) % 360
+                <= (self.azi_max_abs - self.azi_min_abs) % 360
+            )
+            and el > 0
         ]
 
         if not filtered_times:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -2,15 +2,11 @@
 
 from __future__ import annotations
 
-import importlib
 import sys
 from pathlib import Path
 import pytest
 
 sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
-for mod in ["numpy", "pandas", "pytz", "dateutil", "dateutil.parser"]:
-    sys.modules.pop(mod, None)
-importlib.invalidate_caches()
 
 try:
     import custom_components.simple_auto_cover as sac


### PR DESCRIPTION
## Summary
- revert numpy removal so calculations use numpy again
- don't stub out common modules in integration test

## Testing
- `scripts/lint`
- `scripts/test`


------
https://chatgpt.com/codex/tasks/task_e_685ae64df4b4832eae9dac896cc3cdf4