### PR TITLE
Fix translation key naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,8 +103,8 @@ This component provides a simple `basic` strategy for positioning shades based s
       BE --> BM{"Force mode"}
       BF --> BM
       BJ --> BM
-      BM --> |"force open"| BN["Return fully open"]
-      BM --> |"force close"| BO["Return fully closed"]
+      BM --> |"force_open"| BN["Return fully open"]
+      BM --> |"force_close"| BO["Return fully closed"]
       BM --> |auto| BP["Return computed position"]
   end
 ```
@@ -197,7 +197,7 @@ These entities are always available:
 | `switch.{type}_toggle_control_{name}` | `on` | Activates the adaptive control feature. When enabled, blinds adjust based on calculated position, unless manually overridden. |
 | `switch.{type}_manual_override_{name}` | `on` | Enables detection of manual overrides. A cover is marked if its position differs from the calculated one, resetting to adaptive control after a set duration. |
 | `button.{type}_reset_manual_override_{name}` | `on` | Resets manual override tags for all covers; if `switch.{type}_toggle_control_{name}` is on, it also restores blinds to their correct positions. |
-| `select.{type}_force_mode_{name}` | `auto` | Forces the covers to be fully open or closed regardless of normal calculations. Options are `auto`, `force open`, and `force close`. |
+| `select.{type}_force_mode_{name}` | `auto` | Forces the covers to be fully open or closed regardless of normal calculations. Options are `auto`, `force_open`, and `force_close`. |
 
 ## Features Planned
 

--- a/custom_components/simple_auto_cover/coordinator.py
+++ b/custom_components/simple_auto_cover/coordinator.py
@@ -673,10 +673,10 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
     @property
     def state(self) -> int:
         """Return the calculated shade position."""
-        if self.force_mode == "force open":
+        if self.force_mode == "force_open":
             state = 100
             self.logger.debug("Force open position: %s", state)
-        elif self.force_mode == "force close":
+        elif self.force_mode == "force_close":
             state = 0
             self.logger.debug("Force close position: %s", state)
         else:

--- a/custom_components/simple_auto_cover/select.py
+++ b/custom_components/simple_auto_cover/select.py
@@ -11,7 +11,7 @@ from homeassistant.helpers.update_coordinator import CoordinatorEntity
 from .const import DOMAIN, FORCE_MODE
 from .coordinator import AdaptiveDataUpdateCoordinator
 
-OPTIONS = ["auto", "force open", "force close"]
+OPTIONS = ["auto", "force_open", "force_close"]
 
 
 async def async_setup_entry(

--- a/custom_components/simple_auto_cover/strings.json
+++ b/custom_components/simple_auto_cover/strings.json
@@ -402,8 +402,8 @@
       "name": "Force mode",
       "options": {
         "auto": "Auto",
-        "force open": "Force open",
-        "force close": "Force close"
+        "force_open": "Force open",
+        "force_close": "Force close"
       }
     }
   }

--- a/custom_components/simple_auto_cover/translations/en.json
+++ b/custom_components/simple_auto_cover/translations/en.json
@@ -402,8 +402,8 @@
       "name": "Force mode",
       "options": {
         "auto": "Auto",
-        "force open": "Force open",
-        "force close": "Force close"
+        "force_open": "Force open",
+        "force_close": "Force close"
       }
     }
   }

--- a/custom_components/simple_auto_cover/translations/nl.json
+++ b/custom_components/simple_auto_cover/translations/nl.json
@@ -403,8 +403,8 @@
       "name": "Forceermodus",
       "options": {
         "auto": "Auto",
-        "force open": "Openen afdwingen",
-        "force close": "Sluiten afdwingen"
+        "force_open": "Openen afdwingen",
+        "force_close": "Sluiten afdwingen"
       }
     }
   }


### PR DESCRIPTION
## Summary
- fix invalid translation keys for force open/close
- update Python to use new option names
- update docs

## Testing
- `scripts/lint`
- `scripts/test`

------
https://chatgpt.com/codex/tasks/task_e_685b00e676d4832ebbdfd89a69dfd656