### PR TITLE
Update lint script to run formatter

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,8 +4,8 @@ This file defines conventions for automated tools contributing to this repositor
 
 ## Development workflow
 
-- **Formatting and linting**: run `scripts/lint` to automatically format the
-  codebase using `ruff`.
+- **Formatting and linting**: run `scripts/lint` to automatically format and
+  lint the codebase using `ruff`.
 - **Testing**: run `scripts/test` to execute the pytest suite.
 - Add or update tests when modifying functionality or fixing bugs.
 - Include helpful comments for any complicated logic.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -45,8 +45,9 @@ People _love_ thorough bug reports. I'm not even kidding.
 ## Use a Consistent Coding Style
 
 Use [ruff](https://docs.astral.sh/ruff/) to check formatting and linting. Run
-`scripts/lint` (which runs `ruff check . --fix`) to automatically format your
-code and ensure it meets the project's style guidelines.
+`scripts/lint` (which runs `ruff format .` followed by `ruff check . --fix`) to
+automatically format your code and ensure it meets the project's style
+guidelines.
 
 ## Test your code modification
 

--- a/scripts/lint
+++ b/scripts/lint
@@ -4,4 +4,5 @@ set -e
 
 cd "$(dirname "$0")/.."
 
+ruff format .
 ruff check . --fix


### PR DESCRIPTION
## Summary
- run `ruff format` before linting
- clarify docs about using the updated lint script

## Testing
- `poetry run scripts/lint`
- `poetry run scripts/test`


------
https://chatgpt.com/codex/tasks/task_e_685c2a7f90a0832ebfa244bfa16be486