### PR TITLE
Update docs for uv workflow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -12,7 +12,7 @@ This file defines conventions for automated tools contributing to this repositor
 - Provide docstrings for all functions and classes.
 - If these scripts fail because dependencies are missing or the environment lacks
   internet access, note it in the PR testing section.
-- If poetry is installed, which it should be, all commands should be prefixed with `poetry run`. So really run `poetry run scripts/lint` and `poetry run scripts/test`. Or alternatively activate `poetry env activate`
+- If uv is installed, prefix commands with `uv run`. So run `uv run scripts/lint` and `uv run scripts/test`. Alternatively, activate the `.venv` created by `scripts/setup`.
 
 ## Pull request message
 

--- a/scripts/setup
+++ b/scripts/setup
@@ -10,4 +10,4 @@ uv sync --no-progress --all-groups
 echo "Installing pre-commit hooks..."
 uv run pre-commit install --install-hooks
 
-echo "Setup complete. You can now activate the virtual environment with 'poetry env activate' or 'poetry run'."
+echo "Setup complete. You can now run commands with 'uv run' or activate the '.venv' virtual environment."


### PR DESCRIPTION
## Summary
- update contributor docs to use `uv run`
- tweak setup message to reference uv

## Testing
- `uv run scripts/lint`
- `uv run scripts/test`

------
https://chatgpt.com/codex/tasks/task_e_685c3bb5573c832ea9773306c3e4de02