### PR TITLE
Clarify manual override switch label

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ These entities are always available:
 | `binary_sensor.{type}_manual_override_{name}` | `off` | Indicates if manual override is engaged for any blinds. |
 | `binary_sensor.{type}_sun_infront_{name}` | `off` | Indicates whether the sun is in front of the window within the designated field of view. |
 | `switch.{type}_toggle_control_{name}` | `on` | Activates the adaptive control feature. When enabled, blinds adjust based on calculated position, unless manually overridden. |
-| `switch.{type}_manual_override_{name}` | `on` | Enables detection of manual overrides. A cover is marked if its position differs from the calculated one, resetting to adaptive control after a set duration. |
+| `switch.{type}_manual_override_{name}` | `on` | Allows detection of manual overrides. A cover is marked if its position differs from the calculated one, resetting to adaptive control after a set duration. |
 | `button.{type}_reset_manual_override_{name}` | `on` | Resets manual override tags for all covers; if `switch.{type}_toggle_control_{name}` is on, it also restores blinds to their correct positions. |
 | `select.{type}_force_mode_{name}` | `auto` | Forces the covers to be fully open or closed regardless of normal calculations. Options are `auto`, `force_open`, and `force_close`. |
 

--- a/custom_components/simple_auto_cover/switch.py
+++ b/custom_components/simple_auto_cover/switch.py
@@ -32,7 +32,7 @@ async def async_setup_entry(
     manual_switch = AdaptiveCoverSwitch(
         config_entry,
         config_entry.entry_id,
-        "Manual Override",
+        "Allow Manual Override",
         True,
         "manual_toggle",
         coordinator,
@@ -77,7 +77,7 @@ class AdaptiveCoverSwitch(AdaptiveCoverEntity, SwitchEntity, RestoreEntity):
         self._switch_name = switch_name
         self._attr_device_class = device_class
         self._initial_state = initial_state
-        self._attr_unique_id = f"{unique_id}_{switch_name}"
+        self._attr_unique_id = f"{unique_id}_{key}"
 
         self.coordinator.logger.debug("Setup switch")
 

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -189,7 +189,6 @@ def test_switch_initial_state(entity_module, switch_module):
     )
 
     assert isinstance(switch, entity_module.AdaptiveCoverEntity)
-<<<<<<< 0kbwhy-codex/update-label-to--allow-manual-override
     assert switch.name == "Allow Manual Override " + entry.data[CONF_NAME]
     assert switch.unique_id == "uid_manual_toggle"
 
@@ -211,9 +210,6 @@ async def test_switch_async_setup_entry(switch_module):
         f"{entry.entry_id}_control_toggle",
         f"{entry.entry_id}_manual_toggle",
     ]
-=======
-    assert switch.name == "Manual " + entry.data[CONF_NAME]
-    assert switch.unique_id == "uid_Manual"
 
 
 def test_control_sensor_manual(sensor_module):
@@ -251,4 +247,3 @@ def test_select_initialization(entity_module, select_module):
     assert select.name == "Force mode " + entry.data[CONF_NAME]
     assert select.unique_id == f"{entry.entry_id}_force_mode"
 
->>>>>>> mini-cover

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -172,9 +172,33 @@ def test_switch_initial_state(entity_module, switch_module):
     entry = make_entry()
     coord = DummyCoordinator()
     switch = switch_module.AdaptiveCoverSwitch(
-        entry, "uid", "Manual", True, "manual_toggle", coord
+        entry,
+        "uid",
+        "Allow Manual Override",
+        True,
+        "manual_toggle",
+        coord,
     )
 
     assert isinstance(switch, entity_module.AdaptiveCoverEntity)
-    assert switch.name == "Manual " + entry.data[CONF_NAME]
-    assert switch.unique_id == "uid_Manual"
+    assert switch.name == "Allow Manual Override " + entry.data[CONF_NAME]
+    assert switch.unique_id == "uid_manual_toggle"
+
+
+@pytest.mark.asyncio
+async def test_switch_async_setup_entry(switch_module):
+    """Verify switch setup via platform helper."""
+    entry = make_entry()
+    hass = types.SimpleNamespace(data={DOMAIN: {entry.entry_id: DummyCoordinator()}})
+    added: list = []
+
+    await switch_module.async_setup_entry(hass, entry, added.extend)
+
+    assert [e.name for e in added] == [
+        f"Toggle Control {entry.data[CONF_NAME]}",
+        f"Allow Manual Override {entry.data[CONF_NAME]}",
+    ]
+    assert sorted(e.unique_id for e in added) == [
+        f"{entry.entry_id}_control_toggle",
+        f"{entry.entry_id}_manual_toggle",
+    ]


### PR DESCRIPTION
## Summary
- clarify naming by using "Allow Manual Override" for the manual override switch
- keep stable unique_id using the key name
- add a test covering switch setup

## Testing
- `uv run scripts/lint`
- `uv run scripts/test`


------
https://chatgpt.com/codex/tasks/task_e_685d3c2c455c832e82996bf42c7d55a0