### PR TITLE
Cleanup leftover Adaptive Cover names

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug.yml
+++ b/.github/ISSUE_TEMPLATE/bug.yml
@@ -11,7 +11,7 @@ body:
     validations:
       required: true
     attributes:
-      label: What version of Adaptive Cover are you using?
+      label: What version of Simple Auto Cover are you using?
 
   - type: input
     id: homeassistant

--- a/.github/release-drafter.yml
+++ b/.github/release-drafter.yml
@@ -57,7 +57,7 @@ exlude-contributors:
   - "dependabot"
 
 template: |
-  # Adaptive Cover ⛅ v$RESOLVED_VERSION
+  # Simple Auto Cover ⛅ v$RESOLVED_VERSION
   ## Changes
 
   $CHANGES

--- a/custom_components/simple_auto_cover/__init__.py
+++ b/custom_components/simple_auto_cover/__init__.py
@@ -15,7 +15,7 @@ from .const import (
     DOMAIN,
     _LOGGER,
 )
-from .coordinator import AdaptiveDataUpdateCoordinator
+from .coordinator import SimpleAutoCoverDataUpdateCoordinator
 
 PLATFORMS = [
     Platform.SENSOR,
@@ -41,7 +41,7 @@ async def async_setup_entry(hass: HomeAssistant, entry: ConfigEntry) -> bool:
 
     hass.data.setdefault(DOMAIN, {})
 
-    coordinator = AdaptiveDataUpdateCoordinator(hass)
+    coordinator = SimpleAutoCoverDataUpdateCoordinator(hass)
     _cover_entities = entry.options.get(CONF_ENTITIES, [])
     _end_time_entity = entry.options.get(CONF_END_ENTITY)
     _entities = ["sun.sun"]

--- a/custom_components/simple_auto_cover/binary_sensor.py
+++ b/custom_components/simple_auto_cover/binary_sensor.py
@@ -14,8 +14,8 @@ from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import DOMAIN
-from .coordinator import AdaptiveDataUpdateCoordinator
-from .entity import AdaptiveCoverEntity
+from .coordinator import SimpleAutoCoverDataUpdateCoordinator
+from .entity import SimpleAutoCoverEntity
 
 
 async def async_setup_entry(
@@ -24,11 +24,11 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the Simple Auto Cover binary sensor platform."""
-    coordinator: AdaptiveDataUpdateCoordinator = hass.data[DOMAIN][
+    coordinator: SimpleAutoCoverDataUpdateCoordinator = hass.data[DOMAIN][
         config_entry.entry_id
     ]
 
-    binary_sensor = AdaptiveCoverBinarySensor(
+    binary_sensor = SimpleAutoCoverBinarySensor(
         config_entry,
         config_entry.entry_id,
         "Sun Infront",
@@ -37,7 +37,7 @@ async def async_setup_entry(
         BinarySensorDeviceClass.MOTION,
         coordinator,
     )
-    manual_override = AdaptiveCoverBinarySensor(
+    manual_override = SimpleAutoCoverBinarySensor(
         config_entry,
         config_entry.entry_id,
         "Manual Override",
@@ -49,7 +49,7 @@ async def async_setup_entry(
     async_add_entities([binary_sensor, manual_override])
 
 
-class AdaptiveCoverBinarySensor(AdaptiveCoverEntity, BinarySensorEntity):
+class SimpleAutoCoverBinarySensor(SimpleAutoCoverEntity, BinarySensorEntity):
     """Representation of a simple auto cover binary sensor."""
 
     _attr_has_entity_name = True
@@ -63,7 +63,7 @@ class AdaptiveCoverBinarySensor(AdaptiveCoverEntity, BinarySensorEntity):
         state: bool,
         key: str,
         device_class: BinarySensorDeviceClass,
-        coordinator: AdaptiveDataUpdateCoordinator,
+        coordinator: SimpleAutoCoverDataUpdateCoordinator,
     ) -> None:
         """Initialize the binary sensor."""
         super().__init__(config_entry, unique_id, coordinator)

--- a/custom_components/simple_auto_cover/button.py
+++ b/custom_components/simple_auto_cover/button.py
@@ -14,8 +14,8 @@ from .const import (
     CONF_ENTITIES,
     DOMAIN,
 )
-from .coordinator import AdaptiveDataUpdateCoordinator
-from .entity import AdaptiveCoverEntity
+from .coordinator import SimpleAutoCoverDataUpdateCoordinator
+from .entity import SimpleAutoCoverEntity
 
 
 async def async_setup_entry(
@@ -24,11 +24,11 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the button platform."""
-    coordinator: AdaptiveDataUpdateCoordinator = hass.data[DOMAIN][
+    coordinator: SimpleAutoCoverDataUpdateCoordinator = hass.data[DOMAIN][
         config_entry.entry_id
     ]
 
-    reset_manual = AdaptiveCoverButton(
+    reset_manual = SimpleAutoCoverButton(
         config_entry, config_entry.entry_id, "Reset Manual Override", coordinator
     )
 
@@ -41,7 +41,7 @@ async def async_setup_entry(
     async_add_entities(buttons)
 
 
-class AdaptiveCoverButton(AdaptiveCoverEntity, ButtonEntity):
+class SimpleAutoCoverButton(SimpleAutoCoverEntity, ButtonEntity):
     """Representation of a simple auto cover button."""
 
     _attr_has_entity_name = True
@@ -53,7 +53,7 @@ class AdaptiveCoverButton(AdaptiveCoverEntity, ButtonEntity):
         config_entry,
         unique_id: str,
         button_name: str,
-        coordinator: AdaptiveDataUpdateCoordinator,
+        coordinator: SimpleAutoCoverDataUpdateCoordinator,
     ) -> None:
         """Initialize the button."""
         super().__init__(config_entry, unique_id, coordinator)

--- a/custom_components/simple_auto_cover/coordinator.py
+++ b/custom_components/simple_auto_cover/coordinator.py
@@ -88,7 +88,7 @@ from .const import (
     SensorType,
 )
 from .helpers import get_datetime_from_str, get_last_updated, get_safe_state
-from .cover_manager import AdaptiveCoverManager
+from .cover_manager import SimpleAutoCoverManager
 
 
 @dataclass
@@ -101,16 +101,18 @@ class StateChangedData:
 
 
 @dataclass
-class AdaptiveCoverData:
-    """AdaptiveCoverData class."""
+class SimpleAutoCoverData:
+    """SimpleAutoCoverData class."""
 
     climate_mode_toggle: bool
     states: dict
     attributes: dict
 
 
-class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
-    """Adaptive cover data update coordinator."""
+class SimpleAutoCoverDataUpdateCoordinator(
+    DataUpdateCoordinator[SimpleAutoCoverData]
+):
+    """Simple auto cover data update coordinator."""
 
     config_entry: ConfigEntry
 
@@ -142,7 +144,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         self.timed_refresh = False
         self.control_method = "auto"
         self.state_change_data: StateChangedData | None = None
-        self.manager = AdaptiveCoverManager(self.manual_duration, self.logger)
+        self.manager = SimpleAutoCoverManager(self.manual_duration, self.logger)
         self.wait_for_target = {}
         self.target_call = {}
         self.ignore_intermediate_states = self.config_entry.options.get(
@@ -261,7 +263,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         )
         self._scheduled_time = self._end_time
 
-    async def _async_update_data(self) -> AdaptiveCoverData:
+    async def _async_update_data(self) -> SimpleAutoCoverData:
         self.logger.debug("Updating data")
         if self.first_refresh:
             self._cached_options = self.config_entry.options
@@ -321,7 +323,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
             self.logger.debug("Sun start time: %s, Sun end time: %s", start, end)
         else:
             start, end = self._sun_start_time, self._sun_end_time
-        return AdaptiveCoverData(
+        return SimpleAutoCoverData(
             climate_mode_toggle=False,
             states={
                 "state": state,

--- a/custom_components/simple_auto_cover/cover_manager.py
+++ b/custom_components/simple_auto_cover/cover_manager.py
@@ -8,11 +8,11 @@ from homeassistant.util import dt as dt_util
 from .const import SensorType
 
 
-class AdaptiveCoverManager:
+class SimpleAutoCoverManager:
     """Track position changes."""
 
     def __init__(self, reset_duration: dict[str, int], logger) -> None:
-        """Initialize the AdaptiveCoverManager."""
+        """Initialize the SimpleAutoCoverManager."""
         self.covers: set[str] = set()
 
         self.manual_control: dict[str, bool] = {}

--- a/custom_components/simple_auto_cover/entity.py
+++ b/custom_components/simple_auto_cover/entity.py
@@ -7,17 +7,17 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.update_coordinator import CoordinatorEntity
 
 from .const import CONF_SENSOR_TYPE, COVER_TYPE_DISPLAY, DOMAIN
-from .coordinator import AdaptiveDataUpdateCoordinator
+from .coordinator import SimpleAutoCoverDataUpdateCoordinator
 
 
-class AdaptiveCoverEntity(CoordinatorEntity[AdaptiveDataUpdateCoordinator]):
+class SimpleAutoCoverEntity(CoordinatorEntity[SimpleAutoCoverDataUpdateCoordinator]):
     """Common entity base class for Simple Auto Cover."""
 
     def __init__(
         self,
         config_entry,
         unique_id: str,
-        coordinator: AdaptiveDataUpdateCoordinator,
+        coordinator: SimpleAutoCoverDataUpdateCoordinator,
     ) -> None:
         """Initialize the entity."""
         super().__init__(coordinator=coordinator)

--- a/custom_components/simple_auto_cover/select.py
+++ b/custom_components/simple_auto_cover/select.py
@@ -7,10 +7,10 @@ from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
-from .entity import AdaptiveCoverEntity
+from .entity import SimpleAutoCoverEntity
 
 from .const import DOMAIN, FORCE_MODE
-from .coordinator import AdaptiveDataUpdateCoordinator
+from .coordinator import SimpleAutoCoverDataUpdateCoordinator
 
 OPTIONS = ["auto", "force_open", "force_close"]
 
@@ -21,11 +21,11 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the select entity."""
-    coordinator: AdaptiveDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
+    coordinator: SimpleAutoCoverDataUpdateCoordinator = hass.data[DOMAIN][entry.entry_id]
     async_add_entities([SimpleAutoCoverSelect(entry, coordinator)])
 
 
-class SimpleAutoCoverSelect(AdaptiveCoverEntity, SelectEntity):
+class SimpleAutoCoverSelect(SimpleAutoCoverEntity, SelectEntity):
     """Select entity to force cover position."""
 
     _attr_options = OPTIONS
@@ -35,7 +35,7 @@ class SimpleAutoCoverSelect(AdaptiveCoverEntity, SelectEntity):
     def __init__(
         self,
         entry: ConfigEntry,
-        coordinator: AdaptiveDataUpdateCoordinator,
+        coordinator: SimpleAutoCoverDataUpdateCoordinator,
     ) -> None:
         """Initialize the select entity."""
         super().__init__(entry, entry.entry_id, coordinator)

--- a/custom_components/simple_auto_cover/sensor.py
+++ b/custom_components/simple_auto_cover/sensor.py
@@ -18,8 +18,8 @@ from homeassistant.helpers.entity import DeviceInfo
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .const import CONF_SENSOR_TYPE, DOMAIN
-from .coordinator import AdaptiveDataUpdateCoordinator
-from .entity import AdaptiveCoverEntity
+from .coordinator import SimpleAutoCoverDataUpdateCoordinator
+from .entity import SimpleAutoCoverEntity
 
 
 async def async_setup_entry(
@@ -30,14 +30,14 @@ async def async_setup_entry(
     """Initialize Simple Auto Cover config entry."""
 
     name = config_entry.data[CONF_NAME]
-    coordinator: AdaptiveDataUpdateCoordinator = hass.data[DOMAIN][
+    coordinator: SimpleAutoCoverDataUpdateCoordinator = hass.data[DOMAIN][
         config_entry.entry_id
     ]
 
-    sensor = AdaptiveCoverSensorEntity(
+    sensor = SimpleAutoCoverSensorEntity(
         config_entry.entry_id, hass, config_entry, name, coordinator
     )
-    start = AdaptiveCoverTimeSensorEntity(
+    start = SimpleAutoCoverTimeSensorEntity(
         config_entry.entry_id,
         hass,
         config_entry,
@@ -47,7 +47,7 @@ async def async_setup_entry(
         "mdi:sun-clock-outline",
         coordinator,
     )
-    end = AdaptiveCoverTimeSensorEntity(
+    end = SimpleAutoCoverTimeSensorEntity(
         config_entry.entry_id,
         hass,
         config_entry,
@@ -57,13 +57,13 @@ async def async_setup_entry(
         "mdi:sun-clock",
         coordinator,
     )
-    control = AdaptiveCoverControlSensorEntity(
+    control = SimpleAutoCoverControlSensorEntity(
         config_entry.entry_id, hass, config_entry, name, coordinator
     )
     async_add_entities([sensor, start, end, control])
 
 
-class AdaptiveCoverSensorEntity(AdaptiveCoverEntity, SensorEntity):
+class SimpleAutoCoverSensorEntity(SimpleAutoCoverEntity, SensorEntity):
     """Simple Auto Cover Sensor."""
 
     _attr_state_class = SensorStateClass.MEASUREMENT
@@ -78,7 +78,7 @@ class AdaptiveCoverSensorEntity(AdaptiveCoverEntity, SensorEntity):
         hass,
         config_entry,
         name: str,
-        coordinator: AdaptiveDataUpdateCoordinator,
+        coordinator: SimpleAutoCoverDataUpdateCoordinator,
     ) -> None:
         """Initialize simple_auto_cover Sensor."""
         super().__init__(config_entry, unique_id, coordinator)
@@ -116,7 +116,7 @@ class AdaptiveCoverSensorEntity(AdaptiveCoverEntity, SensorEntity):
         return self.data.attributes
 
 
-class AdaptiveCoverTimeSensorEntity(AdaptiveCoverEntity, SensorEntity):
+class SimpleAutoCoverTimeSensorEntity(SimpleAutoCoverEntity, SensorEntity):
     """Simple Auto Cover Time Sensor."""
 
     _attr_device_class = SensorDeviceClass.TIMESTAMP
@@ -132,7 +132,7 @@ class AdaptiveCoverTimeSensorEntity(AdaptiveCoverEntity, SensorEntity):
         sensor_name: str,
         key: str,
         icon: str,
-        coordinator: AdaptiveDataUpdateCoordinator,
+        coordinator: SimpleAutoCoverDataUpdateCoordinator,
     ) -> None:
         """Initialize simple_auto_cover Sensor."""
         super().__init__(config_entry, unique_id, coordinator)
@@ -170,7 +170,7 @@ class AdaptiveCoverTimeSensorEntity(AdaptiveCoverEntity, SensorEntity):
         return self.data.states[self.key]
 
 
-class AdaptiveCoverControlSensorEntity(AdaptiveCoverEntity, SensorEntity):
+class SimpleAutoCoverControlSensorEntity(SimpleAutoCoverEntity, SensorEntity):
     """Simple Auto Cover Control method Sensor."""
 
     _attr_has_entity_name = True
@@ -183,7 +183,7 @@ class AdaptiveCoverControlSensorEntity(AdaptiveCoverEntity, SensorEntity):
         hass,
         config_entry,
         name: str,
-        coordinator: AdaptiveDataUpdateCoordinator,
+        coordinator: SimpleAutoCoverDataUpdateCoordinator,
     ) -> None:
         """Initialize simple_auto_cover Sensor."""
         super().__init__(config_entry, unique_id, coordinator)

--- a/custom_components/simple_auto_cover/switch.py
+++ b/custom_components/simple_auto_cover/switch.py
@@ -15,8 +15,8 @@ from .const import (
     CONF_ENTITIES,
     DOMAIN,
 )
-from .coordinator import AdaptiveDataUpdateCoordinator
-from .entity import AdaptiveCoverEntity
+from .coordinator import SimpleAutoCoverDataUpdateCoordinator
+from .entity import SimpleAutoCoverEntity
 
 
 async def async_setup_entry(
@@ -25,11 +25,11 @@ async def async_setup_entry(
     async_add_entities: AddEntitiesCallback,
 ) -> None:
     """Set up the demo switch platform."""
-    coordinator: AdaptiveDataUpdateCoordinator = hass.data[DOMAIN][
+    coordinator: SimpleAutoCoverDataUpdateCoordinator = hass.data[DOMAIN][
         config_entry.entry_id
     ]
 
-    manual_switch = AdaptiveCoverSwitch(
+    manual_switch = SimpleAutoCoverSwitch(
         config_entry,
         config_entry.entry_id,
         "Manual Override",
@@ -37,7 +37,7 @@ async def async_setup_entry(
         "manual_toggle",
         coordinator,
     )
-    control_switch = AdaptiveCoverSwitch(
+    control_switch = SimpleAutoCoverSwitch(
         config_entry,
         config_entry.entry_id,
         "Toggle Control",
@@ -53,7 +53,7 @@ async def async_setup_entry(
     async_add_entities(switches)
 
 
-class AdaptiveCoverSwitch(AdaptiveCoverEntity, SwitchEntity, RestoreEntity):
+class SimpleAutoCoverSwitch(SimpleAutoCoverEntity, SwitchEntity, RestoreEntity):
     """Representation of a simple auto cover switch."""
 
     _attr_has_entity_name = True
@@ -66,7 +66,7 @@ class AdaptiveCoverSwitch(AdaptiveCoverEntity, SwitchEntity, RestoreEntity):
         switch_name: str,
         initial_state: bool,
         key: str,
-        coordinator: AdaptiveDataUpdateCoordinator,
+        coordinator: SimpleAutoCoverDataUpdateCoordinator,
         device_class: SwitchDeviceClass | None = None,
     ) -> None:
         """Initialize the switch."""

--- a/notebooks/test_env.ipynb
+++ b/notebooks/test_env.ipynb
@@ -274,7 +274,7 @@
     "# slat_distance = 4\n",
     "# depth = 6\n",
     "\n",
-    "# plot_calc = AdaptiveCoverCalculator(\n",
+    "# plot_calc = SimpleAutoCoverCalculator(\n",
     "#     timezone,\n",
     "#     lat,\n",
     "#     lon,\n",

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -36,8 +36,8 @@ class HomeAssistant:
 def make_coordinator(module, cover_type: SensorType = SensorType.BLIND):
     """Instantiate a coordinator and its surrounding fixtures."""
     hass = HomeAssistant()
-    coord = module.AdaptiveDataUpdateCoordinator.__new__(
-        module.AdaptiveDataUpdateCoordinator
+    coord = module.SimpleAutoCoverDataUpdateCoordinator.__new__(
+        module.SimpleAutoCoverDataUpdateCoordinator
     )
     coord.hass = hass
     coord.config_entry = types.SimpleNamespace(data={}, options={})

--- a/tests/test_cover_manager.py
+++ b/tests/test_cover_manager.py
@@ -1,4 +1,4 @@
-"""Tests for AdaptiveCoverManager."""
+"""Tests for SimpleAutoCoverManager."""
 
 from __future__ import annotations
 
@@ -27,10 +27,10 @@ def state_data_class(coordinator):
 
 
 def make_manager(manager_module, seconds=30):
-    """Create an AdaptiveCoverManager instance for testing."""
+    """Create an SimpleAutoCoverManager instance for testing."""
 
     logger = types.SimpleNamespace(debug=lambda *a, **k: None)
-    return manager_module.AdaptiveCoverManager({"seconds": seconds}, logger)
+    return manager_module.SimpleAutoCoverManager({"seconds": seconds}, logger)
 
 
 def make_state(entity_id: str, position: int, cover_type: str | SensorType = "cover"):

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -96,7 +96,7 @@ def test_base_entity_initialization(entity_module):
     """Ensure base entity is initialized with the correct attributes."""
     entry = make_entry()
     coord = DummyCoordinator()
-    entity = entity_module.AdaptiveCoverEntity(entry, "uid", coord)
+    entity = entity_module.SimpleAutoCoverEntity(entry, "uid", coord)
 
     assert entity._device_id == "uid"
     assert entity._name == entry.data[CONF_NAME]
@@ -108,9 +108,9 @@ def test_button_inherits_base(entity_module, button_module):
     """Verify button inherits from the base entity class."""
     entry = make_entry()
     coord = DummyCoordinator()
-    button = button_module.AdaptiveCoverButton(entry, "uid", "Reset", coord)
+    button = button_module.SimpleAutoCoverButton(entry, "uid", "Reset", coord)
 
-    assert isinstance(button, entity_module.AdaptiveCoverEntity)
+    assert isinstance(button, entity_module.SimpleAutoCoverEntity)
     assert button.name == "Reset " + entry.data[CONF_NAME]
     assert (
         button.device_info["name"] == COVER_TYPE_DISPLAY[entry.data[CONF_SENSOR_TYPE]]
@@ -122,7 +122,7 @@ def test_binary_sensor_is_on(entity_module, binary_sensor_module):
     """Confirm binary sensor reports its state correctly."""
     entry = make_entry()
     coord = DummyCoordinator(states={"sun": True, "manual_list": []})
-    sensor = binary_sensor_module.AdaptiveCoverBinarySensor(
+    sensor = binary_sensor_module.SimpleAutoCoverBinarySensor(
         entry,
         "uid",
         "Sun",
@@ -132,7 +132,7 @@ def test_binary_sensor_is_on(entity_module, binary_sensor_module):
         coord,
     )
 
-    assert isinstance(sensor, entity_module.AdaptiveCoverEntity)
+    assert isinstance(sensor, entity_module.SimpleAutoCoverEntity)
     assert sensor.is_on is True
     assert sensor.name == "Sun " + entry.data[CONF_NAME]
     assert sensor.unique_id == "uid_Sun"
@@ -149,14 +149,14 @@ def test_sensor_native_value(entity_module, sensor_module):
     }
     coord = DummyCoordinator(states=states, attrs={"foo": "bar"})
 
-    sensor = sensor_module.AdaptiveCoverSensorEntity(
+    sensor = sensor_module.SimpleAutoCoverSensorEntity(
         "uid", None, entry, entry.data[CONF_NAME], coord
     )
 
     assert sensor.native_value == 55
     assert sensor.extra_state_attributes == {"foo": "bar"}
 
-    time_sensor = sensor_module.AdaptiveCoverTimeSensorEntity(
+    time_sensor = sensor_module.SimpleAutoCoverTimeSensorEntity(
         "uid",
         None,
         entry,
@@ -168,7 +168,7 @@ def test_sensor_native_value(entity_module, sensor_module):
     )
     assert time_sensor.native_value == states["start"]
 
-    control_sensor = sensor_module.AdaptiveCoverControlSensorEntity(
+    control_sensor = sensor_module.SimpleAutoCoverControlSensorEntity(
         "uid", None, entry, entry.data[CONF_NAME], coord
     )
 
@@ -179,11 +179,11 @@ def test_switch_initial_state(entity_module, switch_module):
     """Check initial attributes of the manual override switch."""
     entry = make_entry()
     coord = DummyCoordinator()
-    switch = switch_module.AdaptiveCoverSwitch(
+    switch = switch_module.SimpleAutoCoverSwitch(
         entry, "uid", "Manual", True, "manual_toggle", coord
     )
 
-    assert isinstance(switch, entity_module.AdaptiveCoverEntity)
+    assert isinstance(switch, entity_module.SimpleAutoCoverEntity)
     assert switch.name == "Manual " + entry.data[CONF_NAME]
     assert switch.unique_id == "uid_Manual"
 
@@ -193,7 +193,7 @@ def test_control_sensor_manual(sensor_module):
     entry = make_entry()
     states = {"control": "manual"}
     coord = DummyCoordinator(states=states)
-    control_sensor = sensor_module.AdaptiveCoverControlSensorEntity(
+    control_sensor = sensor_module.SimpleAutoCoverControlSensorEntity(
         "uid", None, entry, entry.data[CONF_NAME], coord
     )
 
@@ -205,13 +205,13 @@ def test_control_sensor_force(sensor_module):
     entry = make_entry()
     states = {"control": "force"}
     coord = DummyCoordinator(states=states)
-    control_sensor = sensor_module.AdaptiveCoverControlSensorEntity(
+    control_sensor = sensor_module.SimpleAutoCoverControlSensorEntity(
         "uid", None, entry, entry.data[CONF_NAME], coord
     )
 
     assert control_sensor.native_value == "force"
 
-    
+
 def test_select_initialization(entity_module, select_module):
     """Validate select entity inherits from the base and is named correctly."""
     entry = make_entry()
@@ -219,7 +219,7 @@ def test_select_initialization(entity_module, select_module):
 
     select = select_module.SimpleAutoCoverSelect(entry, coord)
 
-    assert isinstance(select, entity_module.AdaptiveCoverEntity)
+    assert isinstance(select, entity_module.SimpleAutoCoverEntity)
     assert select.name == "Force mode " + entry.data[CONF_NAME]
     assert select.unique_id == f"{entry.entry_id}_force_mode"
 

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -109,7 +109,7 @@ async def test_initialize_and_lifecycle(monkeypatch):
     monkeypatch.setattr(
         sac, "async_track_state_change_event", dummy_track_state_change_event
     )
-    monkeypatch.setattr(sac, "AdaptiveDataUpdateCoordinator", DummyCoordinator)
+    monkeypatch.setattr(sac, "SimpleAutoCoverDataUpdateCoordinator", DummyCoordinator)
 
     assert await sac.async_initialize_integration(hass) is True
 


### PR DESCRIPTION
## Summary
- update issue template and release draft to show the new name
- rename core classes and tests from AdaptiveCover* to SimpleAutoCover*
- update example notebook

## Testing
- `uv run scripts/lint`
- `uv run scripts/test`

------
https://chatgpt.com/codex/tasks/task_e_685d3e3848ec832eb0fbb3a011a7c32e