### PR TITLE
Add force_no_sunny_area mode

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,7 @@ This component provides a simple `basic` strategy for positioning shades based s
       BJ --> BM
       BM --> |"force_open"| BN["Return fully open"]
       BM --> |"force_close"| BO["Return fully closed"]
+      BM --> |"force_no_sunny_area"| BQ["No sunny area"]
       BM --> |auto| BP["Return computed position"]
   end
 ```
@@ -197,7 +198,7 @@ These entities are always available:
 | `switch.{type}_toggle_control_{name}` | `on` | Activates the adaptive control feature. When enabled, blinds adjust based on calculated position, unless manually overridden. |
 | `switch.{type}_manual_override_{name}` | `on` | Enables detection of manual overrides. A cover is marked if its position differs from the calculated one, resetting to adaptive control after a set duration. |
 | `button.{type}_reset_manual_override_{name}` | `on` | Resets manual override tags for all covers; if `switch.{type}_toggle_control_{name}` is on, it also restores blinds to their correct positions. |
-| `select.{type}_force_mode_{name}` | `auto` | Forces the covers to be fully open or closed regardless of normal calculations. Options are `auto`, `force_open`, and `force_close`. |
+| `select.{type}_force_mode_{name}` | `auto` | Forces the covers to be fully open or closed regardless of normal calculations. Options are `auto`, `force_open`, `force_close`, and `force_no_sunny_area`. |
 
 ## Features Planned
 

--- a/custom_components/simple_auto_cover/const.py
+++ b/custom_components/simple_auto_cover/const.py
@@ -58,6 +58,7 @@ CONF_MANUAL_THRESHOLD = "manual_threshold"
 CONF_MANUAL_IGNORE_INTERMEDIATE = "manual_ignore_intermediate"
 
 FORCE_MODE = "force_mode"
+FORCE_NO_SUNNY_AREA = "force_no_sunny_area"
 
 STRATEGY_MODE_BASIC = "basic"
 STRATEGY_MODES = [STRATEGY_MODE_BASIC]

--- a/custom_components/simple_auto_cover/coordinator.py
+++ b/custom_components/simple_auto_cover/coordinator.py
@@ -82,6 +82,7 @@ from .const import (
     CONF_TILT_DEPTH,
     CONF_TILT_DISTANCE,
     CONF_TILT_MODE,
+    FORCE_NO_SUNNY_AREA,
     CONF_SENSOR_TYPE,
     DOMAIN,
     LOGGER,
@@ -659,7 +660,10 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
 
     def vertical_data(self, options, config):
         """Update data for vertical blinds."""
-        config.distance = options.get(CONF_DISTANCE)
+        if self.force_mode == FORCE_NO_SUNNY_AREA:
+            config.distance = 0
+        else:
+            config.distance = options.get(CONF_DISTANCE)
         config.h_win = options.get(CONF_HEIGHT_WIN)
         return config
 

--- a/custom_components/simple_auto_cover/select.py
+++ b/custom_components/simple_auto_cover/select.py
@@ -9,10 +9,10 @@ from homeassistant.helpers.entity_platform import AddEntitiesCallback
 
 from .entity import AdaptiveCoverEntity
 
-from .const import DOMAIN, FORCE_MODE
+from .const import DOMAIN, FORCE_MODE, FORCE_NO_SUNNY_AREA
 from .coordinator import AdaptiveDataUpdateCoordinator
 
-OPTIONS = ["auto", "force_open", "force_close"]
+OPTIONS = ["auto", "force_open", "force_close", FORCE_NO_SUNNY_AREA]
 
 
 async def async_setup_entry(

--- a/custom_components/simple_auto_cover/strings.json
+++ b/custom_components/simple_auto_cover/strings.json
@@ -37,7 +37,7 @@
         "data": {
           "set_azimuth": "Window Azimuth",
           "window_height": "Window Height",
-          "distance_shaded_area": "Shaded area",
+          "distance_shaded_area": "Sunny Area",
           "default_percentage": "Default Position",
           "min_position": "Minimum Position",
           "max_position": "Maximum Position",
@@ -58,7 +58,7 @@
         "data_description": {
           "set_azimuth": "Adjust Azimuth",
           "window_height": "Specify window height in meters",
-          "distance_shaded_area": "Distance from cover to shaded area in meters",
+          "distance_shaded_area": "Length of sun to allow in meters",
           "default_percentage": "Default cover position as a percentage",
           "min_position": "Minimum adjustable cover position as a percentage",
           "max_position": "Maximum adjustable cover position as a percentage",
@@ -80,7 +80,7 @@
           "length_awning": "Awning Span Length",
           "window_height": "Awning Height",
           "angle": "Awning Angle",
-          "distance_shaded_area": "Shaded area",
+          "distance_shaded_area": "Sunny Area",
           "default_percentage": "Default Position",
           "min_position": "Minimum Position",
           "max_position": "Maximum Position",
@@ -103,7 +103,7 @@
           "window_height": "Adjust the height of the awning from the level of the workarea",
           "length_awning": "Total span length in meters",
           "angle": "Angle of the attached awning measured perpendicular from the wall to the ground",
-          "distance_shaded_area": "Distance from cover to shaded area in meters",
+          "distance_shaded_area": "Length of sun to allow in meters",
           "default_percentage": "Default cover position as a percentage",
           "min_position": "Minimum adjustable cover position as a percentage",
           "max_position": "Maximum adjustable cover position as a percentage",
@@ -231,7 +231,7 @@
         "data": {
           "set_azimuth": "Window Azimuth",
           "window_height": "Window Height",
-          "distance_shaded_area": "Shaded area",
+          "distance_shaded_area": "Sunny Area",
           "default_percentage": "Default Position",
           "min_position": "Minimum Position",
           "max_position": "Maximum Position",
@@ -252,7 +252,7 @@
         "data_description": {
           "set_azimuth": "Adjust Azimuth",
           "window_height": "Specify window height in meters",
-          "distance_shaded_area": "Distance from cover to shaded area in meters",
+          "distance_shaded_area": "Length of sun to allow in meters",
           "default_percentage": "Default cover position as a percentage",
           "min_position": "Minimum adjustable cover position as a percentage",
           "max_position": "Maximum adjustable cover position as a percentage",
@@ -274,7 +274,7 @@
           "length_awning": "Awning Span Length",
           "window_height": "Awning Height",
           "angle": "Awning Angle",
-          "distance_shaded_area": "Shaded area",
+          "distance_shaded_area": "Sunny Area",
           "default_percentage": "Default Position",
           "min_position": "Minimum Position",
           "max_position": "Maximum Position",
@@ -297,7 +297,7 @@
           "window_height": "Adjust the height of the awning from the level of the workarea",
           "length_awning": "Total span length in meters",
           "angle": "Angle of the attached awning measured perpendicular from the wall to the ground",
-          "distance_shaded_area": "Distance from cover to shaded area in meters",
+          "distance_shaded_area": "Length of sun to allow in meters",
           "default_percentage": "Default cover position as a percentage",
           "min_position": "Minimum adjustable cover position as a percentage",
           "max_position": "Maximum adjustable cover position as a percentage",
@@ -403,7 +403,8 @@
       "options": {
         "auto": "Auto",
         "force_open": "Force open",
-        "force_close": "Force close"
+        "force_close": "Force close",
+        "force_no_sunny_area": "No sunny area"
       }
     }
   }

--- a/custom_components/simple_auto_cover/translations/en.json
+++ b/custom_components/simple_auto_cover/translations/en.json
@@ -37,7 +37,7 @@
         "data": {
           "set_azimuth": "Window Azimuth",
           "window_height": "Window Height",
-          "distance_shaded_area": "Shaded area",
+          "distance_shaded_area": "Sunny Area",
           "default_percentage": "Default Position",
           "min_position": "Minimum Position",
           "max_position": "Maximum Position",
@@ -58,7 +58,7 @@
         "data_description": {
           "set_azimuth": "Adjust Azimuth",
           "window_height": "Specify window height in meters",
-          "distance_shaded_area": "Distance from cover to shaded area in meters",
+          "distance_shaded_area": "Length of sun to allow in meters",
           "default_percentage": "Default cover position as a percentage",
           "min_position": "Minimum adjustable cover position as a percentage",
           "max_position": "Maximum adjustable cover position as a percentage",
@@ -80,7 +80,7 @@
           "length_awning": "Awning Span Length",
           "window_height": "Awning Height",
           "angle": "Awning Angle",
-          "distance_shaded_area": "Shaded area",
+          "distance_shaded_area": "Sunny Area",
           "default_percentage": "Default Position",
           "min_position": "Minimum Position",
           "max_position": "Maximum Position",
@@ -103,7 +103,7 @@
           "window_height": "Adjust the height of the awning from the level of the workarea",
           "length_awning": "Total span length in meters",
           "angle": "Angle of the attached awning measured perpendicular from the wall to the ground",
-          "distance_shaded_area": "Distance from cover to shaded area in meters",
+          "distance_shaded_area": "Length of sun to allow in meters",
           "default_percentage": "Default cover position as a percentage",
           "min_position": "Minimum adjustable cover position as a percentage",
           "max_position": "Maximum adjustable cover position as a percentage",
@@ -231,7 +231,7 @@
         "data": {
           "set_azimuth": "Window Azimuth",
           "window_height": "Window Height",
-          "distance_shaded_area": "Shaded area",
+          "distance_shaded_area": "Sunny Area",
           "default_percentage": "Default Position",
           "min_position": "Minimum Position",
           "max_position": "Maximum Position",
@@ -252,7 +252,7 @@
         "data_description": {
           "set_azimuth": "Adjust Azimuth",
           "window_height": "Specify window height in meters",
-          "distance_shaded_area": "Distance from cover to shaded area in meters",
+          "distance_shaded_area": "Length of sun to allow in meters",
           "default_percentage": "Default cover position as a percentage",
           "min_position": "Minimum adjustable cover position as a percentage",
           "max_position": "Maximum adjustable cover position as a percentage",
@@ -274,7 +274,7 @@
           "length_awning": "Awning Span Length",
           "window_height": "Awning Height",
           "angle": "Awning Angle",
-          "distance_shaded_area": "Shaded area",
+          "distance_shaded_area": "Sunny Area",
           "default_percentage": "Default Position",
           "min_position": "Minimum Position",
           "max_position": "Maximum Position",
@@ -297,7 +297,7 @@
           "window_height": "Adjust the height of the awning from the level of the workarea",
           "length_awning": "Total span length in meters",
           "angle": "Angle of the attached awning measured perpendicular from the wall to the ground",
-          "distance_shaded_area": "Distance from cover to shaded area in meters",
+          "distance_shaded_area": "Length of sun to allow in meters",
           "default_percentage": "Default cover position as a percentage",
           "min_position": "Minimum adjustable cover position as a percentage",
           "max_position": "Maximum adjustable cover position as a percentage",
@@ -403,7 +403,8 @@
       "options": {
         "auto": "Auto",
         "force_open": "Force open",
-        "force_close": "Force close"
+        "force_close": "Force close",
+        "force_no_sunny_area": "No sunny area"
       }
     }
   }

--- a/custom_components/simple_auto_cover/translations/nl.json
+++ b/custom_components/simple_auto_cover/translations/nl.json
@@ -37,7 +37,7 @@
         "data": {
           "set_azimuth": "Raam Azimuth",
           "window_height": "Raamhoogte",
-          "distance_shaded_area": "Beschaduwde gebied",
+          "distance_shaded_area": "Zonnig gebied",
           "default_percentage": "Standaard positie",
           "min_position": "Minimale positie",
           "max_position": "Maximale positie",
@@ -58,7 +58,7 @@
         "data_description": {
           "set_azimuth": "Stel Azimuth in",
           "window_height": "Specificeer raamhoogte in meters",
-          "distance_shaded_area": "Afstand van bekleding tot beschaduwd gebied in meters",
+          "distance_shaded_area": "Lengte zon die wordt toegelaten in meters",
           "default_percentage": "Standaard bekledingspositie als percentage",
           "min_position": "Minimale verstelbare bekledingspositie als percentage",
           "max_position": "Maximale verstelbare bekledingspositie als percentage",
@@ -80,7 +80,7 @@
           "length_awning": "Zonneschermspanlengte",
           "window_height": "Zonneschermhoogte",
           "angle": "Zonneschermhoek",
-          "distance_shaded_area": "Beschaduwde gebied",
+          "distance_shaded_area": "Zonnig gebied",
           "default_percentage": "Standaard positie",
           "min_position": "Minimale positie",
           "max_position": "Maximale positie",
@@ -103,7 +103,7 @@
           "window_height": "Pas de hoogte van het zonnescherm aan vanaf de hoogte van het werkgebied",
           "length_awning": "Totale spanwijdte van het zonnescherm in meters",
           "angle": "Hoek van het bevestigde zonnescherm gemeten loodrecht vanaf de muur naar de grond",
-          "distance_shaded_area": "Afstand van bekleding tot beschaduwd gebied in meters",
+          "distance_shaded_area": "Lengte zon die wordt toegelaten in meters",
           "default_percentage": "Standaard bekledingspositie als percentage",
           "min_position": "Minimale verstelbare bekledingspositie als percentage",
           "max_position": "Maximale verstelbare bekledingspositie als percentage",
@@ -230,7 +230,7 @@
         "data": {
           "set_azimuth": "Raam Azimuth",
           "window_height": "Raamhoogte",
-          "distance_shaded_area": "Beschaduwde gebied",
+          "distance_shaded_area": "Zonnig gebied",
           "default_percentage": "Standaard positie",
           "min_position": "Minimale positie",
           "max_position": "Maximale positie",
@@ -251,7 +251,7 @@
         "data_description": {
           "set_azimuth": "Stel Azimuth in",
           "window_height": "Specificeer raamhoogte in meters",
-          "distance_shaded_area": "Afstand van bekleding tot beschaduwd gebied in meters",
+          "distance_shaded_area": "Lengte zon die wordt toegelaten in meters",
           "default_percentage": "Standaard bekledingspositie als percentage",
           "min_position": "Minimale verstelbare bekledingspositie als percentage",
           "max_position": "Maximale verstelbare bekledingspositie als percentage",
@@ -273,7 +273,7 @@
           "length_awning": "Zonneschermspanlengte",
           "window_height": "Zonneschermhoogte",
           "angle": "Zonneschermhoek",
-          "distance_shaded_area": "Beschaduwde gebied",
+          "distance_shaded_area": "Zonnig gebied",
           "default_percentage": "Standaard positie",
           "min_position": "Minimale positie",
           "max_position": "Maximale positie",
@@ -296,7 +296,7 @@
           "window_height": "Pas de hoogte van het zonnescherm aan vanaf de hoogte van het werkgebied",
           "length_awning": "Totale spanwijdte van het zonnescherm in meters",
           "angle": "Hoek van het bevestigde zonnescherm gemeten loodrecht vanaf de muur naar de grond",
-          "distance_shaded_area": "Afstand van bekleding tot beschaduwd gebied in meters",
+          "distance_shaded_area": "Lengte zon die wordt toegelaten in meters",
           "default_percentage": "Standaard bekledingspositie als percentage",
           "min_position": "Minimale verstelbare bekledingspositie als percentage",
           "max_position": "Maximale verstelbare bekledingspositie als percentage",
@@ -404,7 +404,8 @@
       "options": {
         "auto": "Auto",
         "force_open": "Openen afdwingen",
-        "force_close": "Sluiten afdwingen"
+        "force_close": "Sluiten afdwingen",
+        "force_no_sunny_area": "Geen zon toestaan"
       }
     }
   }

--- a/tests/test_coordinator.py
+++ b/tests/test_coordinator.py
@@ -198,3 +198,16 @@ def test_interpolate_states_full_range(module):
     coord.normal_list = []
     coord.new_list = []
     assert coord.interpolate_states(50) == 50
+
+
+def test_vertical_data_force_no_sunny_area(module):
+    """Distance is set to zero when forcing no sunny area."""
+    from custom_components.simple_auto_cover.const import CONF_DISTANCE, CONF_HEIGHT_WIN, FORCE_NO_SUNNY_AREA
+
+    coord, _ = make_coordinator(module)
+    coord.force_mode = FORCE_NO_SUNNY_AREA
+    options = {CONF_DISTANCE: 0.5, CONF_HEIGHT_WIN: 2.0}
+    config = module.CoverConfig()
+    coord.vertical_data(options, config)
+
+    assert config.distance == 0


### PR DESCRIPTION
## Summary
- add a constant and option for `force_no_sunny_area`
- respect the new force mode in coordinator distance logic
- rename "Shaded area" to "Sunny Area" in strings and translations
- update README for new force mode
- test coordinator vertical_data with the new mode

## Testing
- `scripts/lint`
- `scripts/test`


------
https://chatgpt.com/codex/tasks/task_e_685d4a36c30c832eb7a6782995de50d5