### PR TITLE
Fix README path for screenshot

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ Restart Home-Assistant and add the integration.
 
 ### Manual
 
-Download the `adaptive_cover` folder from this github.
+Download the `simple_auto_cover` folder from this github.
 Add the folder to `config/custom_components/`.
 
 Restart Home-Assistant and add the integration.
@@ -210,4 +210,4 @@ These entities are always available:
 
 ### Simulation
 
-![combined_simulation](custom_components/adaptive_cover/simulation/sim_plot.png)
+![combined_simulation](custom_components/simple_auto_cover/simulation/sim_plot.png)

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -211,7 +211,7 @@ def test_control_sensor_force(sensor_module):
 
     assert control_sensor.native_value == "force"
 
-    
+
 def test_select_initialization(entity_module, select_module):
     """Validate select entity inherits from the base and is named correctly."""
     entry = make_entry()


### PR DESCRIPTION
## Summary
- correct outdated folder name in manual install instructions
- update simulation screenshot path

## Testing
- `scripts/lint`
- `scripts/test`


------
https://chatgpt.com/codex/tasks/task_e_685d48fcdd88832ea6e3a8dcbec57141