### PR TITLE
Parametrize calculation test

### DIFF
--- a/README.md
+++ b/README.md
@@ -189,7 +189,7 @@ These entities are always available:
 | Entities | Default | Description |
 | --------------------------------------------- | -------------- | ---------------------------------------------------------------------------------------------------------------------- |
 | `sensor.{type}_cover_position_{name}` | | Reflects the current state determined by predefined settings and factors such as sun position, weather, and temperature |
-| `sensor.{type}_control_method_{name}` | `intermediate` | Indicates the active control strategy based on weather conditions. Options include `winter`, `summer`, and `intermediate` |
+| `sensor.{type}_control_method_{name}` | `auto` | Indicates the active control mode. Values are `auto`, `force`, and `manual`. |
 | `sensor.{type}_start_sun_{name}` | | Shows the starting time when the sun enters the window's view, with an interval of every 5 minutes. |
 | `sensor.{type}_end_sun_{name}` | | Indicates the ending time when the sun exits the window's view, with an interval of every 5 minutes. |
 | `binary_sensor.{type}_manual_override_{name}` | `off` | Indicates if manual override is engaged for any blinds. |

--- a/README.md
+++ b/README.md
@@ -195,7 +195,7 @@ These entities are always available:
 | `binary_sensor.{type}_manual_override_{name}` | `off` | Indicates if manual override is engaged for any blinds. |
 | `binary_sensor.{type}_sun_infront_{name}` | `off` | Indicates whether the sun is in front of the window within the designated field of view. |
 | `switch.{type}_toggle_control_{name}` | `on` | Activates the adaptive control feature. When enabled, blinds adjust based on calculated position, unless manually overridden. |
-| `switch.{type}_manual_override_{name}` | `on` | Enables detection of manual overrides. A cover is marked if its position differs from the calculated one, resetting to adaptive control after a set duration. |
+| `switch.{type}_manual_override_{name}` | `on` | Allows detection of manual overrides. A cover is marked if its position differs from the calculated one, resetting to adaptive control after a set duration. |
 | `button.{type}_reset_manual_override_{name}` | `on` | Resets manual override tags for all covers; if `switch.{type}_toggle_control_{name}` is on, it also restores blinds to their correct positions. |
 | `select.{type}_force_mode_{name}` | `auto` | Forces the covers to be fully open or closed regardless of normal calculations. Options are `auto`, `force_open`, and `force_close`. |
 

--- a/custom_components/simple_auto_cover/coordinator.py
+++ b/custom_components/simple_auto_cover/coordinator.py
@@ -140,7 +140,7 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         self.cover_state_change = False
         self.first_refresh = False
         self.timed_refresh = False
-        self.control_method = "intermediate"
+        self.control_method = "auto"
         self.state_change_data: StateChangedData | None = None
         self.manager = AdaptiveCoverManager(self.manual_duration, self.logger)
         self.wait_for_target = {}
@@ -276,8 +276,6 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         # Update manager with covers
         self._update_manager_and_covers()
 
-        self.logger.debug("Control method is %s", self.control_method)
-
         # calculate the state of the cover
         self.normal_cover_state = NormalCoverState(cover_data)
         self.logger.debug(
@@ -289,6 +287,14 @@ class AdaptiveDataUpdateCoordinator(DataUpdateCoordinator[AdaptiveCoverData]):
         state = self.state
 
         await self.manager.reset_if_needed()
+
+        if self.manager.binary_cover_manual:
+            self.control_method = "manual"
+        elif self.force_mode != "auto":
+            self.control_method = "force"
+        else:
+            self.control_method = "auto"
+        self.logger.debug("Control method is %s", self.control_method)
 
         if (
             self._end_time

--- a/custom_components/simple_auto_cover/icons.json
+++ b/custom_components/simple_auto_cover/icons.json
@@ -18,8 +18,8 @@
       "control": {
         "default": "mdi:white-balance-sunny",
         "state": {
-          "winter": "mdi:snowflake",
-          "summer": "mdi:heat-wave"
+          "force": "mdi:hand-back-right",
+          "manual": "mdi:account-wrench"
         }
       }
     },

--- a/custom_components/simple_auto_cover/select.py
+++ b/custom_components/simple_auto_cover/select.py
@@ -6,7 +6,8 @@ from homeassistant.components.select import SelectEntity
 from homeassistant.config_entries import ConfigEntry
 from homeassistant.core import HomeAssistant
 from homeassistant.helpers.entity_platform import AddEntitiesCallback
-from homeassistant.helpers.update_coordinator import CoordinatorEntity
+
+from .entity import AdaptiveCoverEntity
 
 from .const import DOMAIN, FORCE_MODE
 from .coordinator import AdaptiveDataUpdateCoordinator
@@ -24,9 +25,7 @@ async def async_setup_entry(
     async_add_entities([SimpleAutoCoverSelect(entry, coordinator)])
 
 
-class SimpleAutoCoverSelect(
-    CoordinatorEntity[AdaptiveDataUpdateCoordinator], SelectEntity
-):
+class SimpleAutoCoverSelect(AdaptiveCoverEntity, SelectEntity):
     """Select entity to force cover position."""
 
     _attr_options = OPTIONS
@@ -34,12 +33,19 @@ class SimpleAutoCoverSelect(
     _attr_translation_key = FORCE_MODE
 
     def __init__(
-        self, entry: ConfigEntry, coordinator: AdaptiveDataUpdateCoordinator
+        self,
+        entry: ConfigEntry,
+        coordinator: AdaptiveDataUpdateCoordinator,
     ) -> None:
         """Initialize the select entity."""
-        super().__init__(coordinator)
+        super().__init__(entry, entry.entry_id, coordinator)
         self._attr_unique_id = f"{entry.entry_id}_force_mode"
         self.coordinator = coordinator
+
+    @property
+    def name(self) -> str:
+        """Return the entity name."""
+        return f"Force mode {self._name}"
 
     @property
     def current_option(self) -> str:

--- a/custom_components/simple_auto_cover/switch.py
+++ b/custom_components/simple_auto_cover/switch.py
@@ -32,7 +32,7 @@ async def async_setup_entry(
     manual_switch = AdaptiveCoverSwitch(
         config_entry,
         config_entry.entry_id,
-        "Manual Override",
+        "Allow Manual Override",
         True,
         "manual_toggle",
         coordinator,
@@ -77,7 +77,7 @@ class AdaptiveCoverSwitch(AdaptiveCoverEntity, SwitchEntity, RestoreEntity):
         self._switch_name = switch_name
         self._attr_device_class = device_class
         self._initial_state = initial_state
-        self._attr_unique_id = f"{unique_id}_{switch_name}"
+        self._attr_unique_id = f"{unique_id}_{key}"
 
         self.coordinator.logger.debug("Setup switch")
 

--- a/tests/test_calculation.py
+++ b/tests/test_calculation.py
@@ -69,11 +69,25 @@ class TestVerticalCover:
         return cover
 
 
-def test_vertical_cover_calculation(module):
+@pytest.mark.parametrize(
+    "sol_azi, sol_elev, win_azi, expected_pos, expected_pct",
+    [
+        (0, 45, 0, 1.0, 50),
+        (0, 60, 0, 1.7320508075688767, 87),
+        (0, 30, 0, 0.5773502691896257, 29),
+        (30, 45, 0, 1.1547005383792512, 58),
+        (-30, 45, 0, 1.1547005383792512, 58),
+    ],
+)
+def test_vertical_cover_calculation(
+    module, sol_azi, sol_elev, win_azi, expected_pos, expected_pct
+):
     """Test calculation of the adaptive vertical cover."""
-    cover = TestVerticalCover.make_cover(module)
-    assert cover.calculate_position() == pytest.approx(1)
-    assert cover.calculate_percentage() == 50
+    cover = TestVerticalCover.make_cover(
+        module, sol_azi=sol_azi, sol_elev=sol_elev, win_azi=win_azi
+    )
+    assert cover.calculate_position() == pytest.approx(expected_pos)
+    assert cover.calculate_percentage() == expected_pct
 
 
 def test_normal_cover_state_default(module):

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -178,3 +178,27 @@ def test_switch_initial_state(entity_module, switch_module):
     assert isinstance(switch, entity_module.AdaptiveCoverEntity)
     assert switch.name == "Manual " + entry.data[CONF_NAME]
     assert switch.unique_id == "uid_Manual"
+
+
+def test_control_sensor_manual(sensor_module):
+    """Control sensor reports manual mode."""
+    entry = make_entry()
+    states = {"control": "manual"}
+    coord = DummyCoordinator(states=states)
+    control_sensor = sensor_module.AdaptiveCoverControlSensorEntity(
+        "uid", None, entry, entry.data[CONF_NAME], coord
+    )
+
+    assert control_sensor.native_value == "manual"
+
+
+def test_control_sensor_force(sensor_module):
+    """Control sensor reports force mode."""
+    entry = make_entry()
+    states = {"control": "force"}
+    coord = DummyCoordinator(states=states)
+    control_sensor = sensor_module.AdaptiveCoverControlSensorEntity(
+        "uid", None, entry, entry.data[CONF_NAME], coord
+    )
+
+    assert control_sensor.native_value == "force"

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -235,7 +235,7 @@ def test_control_sensor_force(sensor_module):
 
     assert control_sensor.native_value == "force"
 
-    
+
 def test_select_initialization(entity_module, select_module):
     """Validate select entity inherits from the base and is named correctly."""
     entry = make_entry()

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -189,7 +189,6 @@ def test_switch_initial_state(entity_module, switch_module):
     )
 
     assert isinstance(switch, entity_module.AdaptiveCoverEntity)
-<<<<<<< 0kbwhy-codex/update-label-to--allow-manual-override
     assert switch.name == "Allow Manual Override " + entry.data[CONF_NAME]
     assert switch.unique_id == "uid_manual_toggle"
 
@@ -211,9 +210,6 @@ async def test_switch_async_setup_entry(switch_module):
         f"{entry.entry_id}_control_toggle",
         f"{entry.entry_id}_manual_toggle",
     ]
-=======
-    assert switch.name == "Manual " + entry.data[CONF_NAME]
-    assert switch.unique_id == "uid_Manual"
 
 
 def test_control_sensor_manual(sensor_module):
@@ -251,4 +247,3 @@ def test_select_initialization(entity_module, select_module):
     assert select.name == "Force mode " + entry.data[CONF_NAME]
     assert select.unique_id == f"{entry.entry_id}_force_mode"
 
->>>>>>> mini-cover

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -172,9 +172,33 @@ def test_switch_initial_state(entity_module, switch_module):
     entry = make_entry()
     coord = DummyCoordinator()
     switch = switch_module.AdaptiveCoverSwitch(
-        entry, "uid", "Manual", True, "manual_toggle", coord
+        entry,
+        "uid",
+        "Allow Manual Override",
+        True,
+        "manual_toggle",
+        coord,
     )
 
     assert isinstance(switch, entity_module.AdaptiveCoverEntity)
-    assert switch.name == "Manual " + entry.data[CONF_NAME]
-    assert switch.unique_id == "uid_Manual"
+    assert switch.name == "Allow Manual Override " + entry.data[CONF_NAME]
+    assert switch.unique_id == "uid_manual_toggle"
+
+
+@pytest.mark.asyncio
+async def test_switch_async_setup_entry(switch_module):
+    """Verify switch setup via platform helper."""
+    entry = make_entry()
+    hass = types.SimpleNamespace(data={DOMAIN: {entry.entry_id: DummyCoordinator()}})
+    added: list = []
+
+    await switch_module.async_setup_entry(hass, entry, added.extend)
+
+    assert [e.name for e in added] == [
+        f"Toggle Control {entry.data[CONF_NAME]}",
+        f"Allow Manual Override {entry.data[CONF_NAME]}",
+    ]
+    assert sorted(e.unique_id for e in added) == [
+        f"{entry.entry_id}_control_toggle",
+        f"{entry.entry_id}_manual_toggle",
+    ]

--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -53,6 +53,14 @@ def switch_module():
     return switch
 
 
+@pytest.fixture
+def select_module():
+    """Return the select module for import testing."""
+    import custom_components.simple_auto_cover.select as select
+
+    return select
+
+
 class DummyCoordinator:
     """Simplified coordinator for entity tests."""
 
@@ -178,3 +186,15 @@ def test_switch_initial_state(entity_module, switch_module):
     assert isinstance(switch, entity_module.AdaptiveCoverEntity)
     assert switch.name == "Manual " + entry.data[CONF_NAME]
     assert switch.unique_id == "uid_Manual"
+
+
+def test_select_initialization(entity_module, select_module):
+    """Validate select entity inherits from the base and is named correctly."""
+    entry = make_entry()
+    coord = DummyCoordinator()
+
+    select = select_module.SimpleAutoCoverSelect(entry, coord)
+
+    assert isinstance(select, entity_module.AdaptiveCoverEntity)
+    assert select.name == "Force mode " + entry.data[CONF_NAME]
+    assert select.unique_id == f"{entry.entry_id}_force_mode"


### PR DESCRIPTION
## Summary
- expand vertical cover tests using pytest parametrize
- apply ruff formatting fixes to existing tests

## Testing
- `uv run scripts/lint`
- `uv run scripts/test`


------
https://chatgpt.com/codex/tasks/task_e_685d493cee5c832eb8883c08db03ff49