### PR TITLE
Fix failing test

### DIFF
--- a/tests/test_entities.py
+++ b/tests/test_entities.py
@@ -188,7 +188,7 @@ def test_switch_initial_state(entity_module, switch_module):
         coord,
     )
 
-    assert isinstance(switch, entity_module.AdaptiveCoverEntity)
+    assert isinstance(switch, entity_module.SimpleAutoCoverEntity)
     assert switch.name == "Allow Manual Override " + entry.data[CONF_NAME]
     assert switch.unique_id == "uid_manual_toggle"
 


### PR DESCRIPTION
## Summary
- fix failing unit test referencing old class name

## Testing
- `scripts/lint`
- `scripts/test`

------
https://chatgpt.com/codex/tasks/task_e_685ff30eecf0832e9e33b15145577696